### PR TITLE
Made change to allow last example to be run in runexample.sh.

### DIFF
--- a/runexamples.sh
+++ b/runexamples.sh
@@ -115,7 +115,7 @@ then
   elif [ $which_one = 'q' ]  # accept 'q' as "quit".
   then
     exit 0
-  elif [ $which_one -lt 0 -o $which_one -ge ${#arr[@]} ]
+  elif [ $which_one -le 0 -o $which_one -gt ${#arr[@]} ]
   then
     echo "ERROR: Must enter a number between 1 and ${#arr[@]}."
     exit 1


### PR DESCRIPTION
Indices were being used as if starting at 0 in an elif, when in fact they start at 1. Thus last example didn't run plus when entering 0 another example which shouldn't be run, was run.