### PR TITLE
Add nd4j-cuda-8.0-platform to dependencyManagement.

### DIFF
--- a/dl4j-cuda-specific-examples/pom.xml
+++ b/dl4j-cuda-specific-examples/pom.xml
@@ -49,12 +49,17 @@
                 <artifactId>nd4j-native-platform</artifactId>
                 <version>${nd4j.version}</version>
             </dependency>
-            <dependency>
+             <dependency>
                 <groupId>org.nd4j</groupId>
                 <artifactId>nd4j-cuda-7.5-platform</artifactId>
                 <version>${nd4j.version}</version>
             </dependency>
-        </dependencies>
+            <dependency>
+                <groupId>org.nd4j</groupId>
+                <artifactId>nd4j-cuda-8.0-platform</artifactId>
+                <version>${nd4j.version}</version>
+            </dependency>
+      </dependencies>
     </dependencyManagement>
 
     <dependencies>

--- a/dl4j-examples/pom.xml
+++ b/dl4j-examples/pom.xml
@@ -51,7 +51,12 @@
                 <artifactId>nd4j-cuda-7.5-platform</artifactId>
                 <version>${nd4j.version}</version>
             </dependency>
-        </dependencies>
+            <dependency>
+                <groupId>org.nd4j</groupId>
+                <artifactId>nd4j-cuda-8.0-platform</artifactId>
+                <version>${nd4j.version}</version>
+            </dependency>
+       </dependencies>
     </dependencyManagement>
 
     <dependencies>


### PR DESCRIPTION
This makes it easier for people to switch the backend to cuda-8.0.