### PR TITLE
Fix evalTimeSeries argument order

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/video/VideoClassificationExample.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/video/VideoClassificationExample.java
@@ -193,7 +193,7 @@ public class VideoClassificationExample {
             DataSet dsTest = testData.next();
             INDArray predicted = net.output(dsTest.getFeatureMatrix(), false);
             INDArray actual = dsTest.getLabels();
-            evaluation.evalTimeSeries(predicted, actual);
+            evaluation.evalTimeSeries(actual, predicted);
         }
 
         System.out.println(evaluation.stats());


### PR DESCRIPTION
When evaluating the time series, line 196 reads
evaluation.evalTimeSeries(predicted, actual);
Changed now to
evaluation.evalTimeSeries(actual, predicted);