### PR TITLE
PredictGenderTrain.java  frequently didn't converge.  Decreasing learning rate solved it for me.

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/feedforward/classification/detectgender/PredictGenderTrain.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/feedforward/classification/detectgender/PredictGenderTrain.java
@@ -49,7 +49,7 @@ public class PredictGenderTrain
     public void train()
     {
         int seed = 123456;
-        double learningRate = 0.01;
+        double learningRate = 0.005;// was .01 but often got errors: "o.d.optimize.solvers.BaseOptimizer - Hit termination condition on iteration 0"
         int batchSize = 100;
         int nEpochs = 100;
         int numInputs = 0;


### PR DESCRIPTION
I thought someone at DL4J would like to know: The PredictGenderTrain dl4j example frequently does not learn/converge (~50% error through all epochs). It seems to work reliably when I reduce the learningRate = 0.005;//GF was .01 
So, you might update source code.
Adam Gibson told me to let you know as a Pull Request instead of Gitter Chat.  I think he's a busy guy.