### PR TITLE
Update Javadoc comment.

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataExamples/ImageDrawer.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataExamples/ImageDrawer.java
@@ -26,6 +26,7 @@ import org.nd4j.linalg.lossfunctions.LossFunctions;
  * Demonstrates how to feed an NN with externally originated data.
  *
  * This example uses JavaFX, which requires the Oracle JDK. Comment out this example if you use a different JDK.
+ * OpenJDK and openjfx have been reported to work fine.
  *
  * TODO: sample does not shut down correctly. Process must be stopped from the IDE.
  *

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataExamples/ImageDrawer.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataExamples/ImageDrawer.java
@@ -25,6 +25,8 @@ import org.nd4j.linalg.lossfunctions.LossFunctions;
  * JavaFX application to show a neural network learning to draw an image.
  * Demonstrates how to feed an NN with externally originated data.
  *
+ * This example uses JavaFX, which requires the Oracle JDK. Comment out this example if you use a different JDK.
+ *
  * TODO: sample does not shut down correctly. Process must be stopped from the IDE.
  *
  * @author Robert Altena


### PR DESCRIPTION
Example uses Javafx, hence requires Oracle JDK.
#2608