### PR TITLE
Fix issue with sampleFromDistribution

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/GravesLSTMCharModellingExample.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/GravesLSTMCharModellingExample.java
@@ -207,13 +207,19 @@ public class GravesLSTMCharModellingExample {
 	 * @param distribution Probability distribution over classes. Must sum to 1.0
 	 */
 	public static int sampleFromDistribution( double[] distribution, Random rng ){
-		double d = rng.nextDouble();
-		double sum = 0.0;
-		for( int i=0; i<distribution.length; i++ ){
-			sum += distribution[i];
-			if( d <= sum ) return i;
-		}
-		//Should never happen if distribution is a valid probability distribution
+	    double d = 0.0;
+	    double sum = 0.0;
+	    for( int t=0; t<10; t++ ) {
+            d = rng.nextDouble();
+            sum = 0.0;
+            for( int i=0; i<distribution.length; i++ ){
+                sum += distribution[i];
+                if( d <= sum ) return i;
+            }
+            //If we haven't found the right index yet, maybe the sum is slightly
+            //lower than 1 due to rounding error, so try again.
+        }
+		//Should be extremely unlikely to happen if distribution is a valid probability distribution
 		throw new IllegalArgumentException("Distribution is invalid? d="+d+", sum="+sum);
 	}
 }


### PR DESCRIPTION
In the GravesLSTMCharModellingExample class, the sampleFromDistribution method was assuming that its input distribution would sum to 1. However, rounding error means that this is not guaranteed to be the case. I had the demo crash because the randomly chosen number was 0.99999993, but the sum was only 0.99999985.

Fix this issue by having sampleFromDistribution try up to 10 times.

I hereby release this contribution under the Apache License, Version 2.0.