### PR TITLE
Remove duplicated dependencies from dl4j-cuda-specific-examples/pom.xml

### DIFF
--- a/dl4j-cuda-specific-examples/pom.xml
+++ b/dl4j-cuda-specific-examples/pom.xml
@@ -49,21 +49,6 @@
                 <artifactId>nd4j-native-platform</artifactId>
                 <version>${nd4j.version}</version>
             </dependency>
-             <dependency>
-                <groupId>org.nd4j</groupId>
-                <artifactId>nd4j-cuda-7.5-platform</artifactId>
-                <version>${nd4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.nd4j</groupId>
-                <artifactId>nd4j-cuda-8.0-platform</artifactId>
-                <version>${nd4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.nd4j</groupId>
-                <artifactId>nd4j-native-platform</artifactId>
-                <version>${nd4j.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.nd4j</groupId>
                 <artifactId>nd4j-cuda-7.5-platform</artifactId>


### PR DESCRIPTION
You can see the dependencies that were duplicated adjacent to the ones that were removed. This prevented mvn clean install from working for me, due to the linter you have installed here: https://github.com/deeplearning4j/dl4j-examples/blob/master/pom.xml#L98