### PR TITLE
Increment epoch counter after epoch complete output for AdditionRNN example

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/seq2seq/AdditionRNN.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/seq2seq/AdditionRNN.java
@@ -127,7 +127,6 @@ public class AdditionRNN {
             MultiDataSet testData = iterator.generateTest(testSize);
             INDArray predictions = predictor.output(testData);
             encode_decode_eval(predictions,testData.getFeatures()[0],testData.getLabels()[0]);
-            iEpoch++;
             /*
             (Comment/Uncomment) the following block of code to (see/or not see) how the output of the decoder is fed back into the input during test time
             */
@@ -135,6 +134,7 @@ public class AdditionRNN {
             testData = iterator.generateTest(3);
             predictor.output(testData,true);
             System.out.println("\n* = * = * = * = * = * = * = * = * = ** EPOCH " + iEpoch + " COMPLETE ** = * = * = * = * = * = * = * = * = * = * = * = * = * =");
+            iEpoch++;
         }
 
     }


### PR DESCRIPTION
Within the AdditionRNN class, I moved the epoch counter so that when an epoch completes, it refers to the right one.
