### PR TITLE
Adding an example of the use of a mixture density loss function

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/misc/lossfunctions/GaussianMixtureIterator.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/misc/lossfunctions/GaussianMixtureIterator.java
@@ -1,0 +1,174 @@
+package org.deeplearning4j.examples.misc.lossfunctions;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Random;
+import org.apache.commons.math3.distribution.MultivariateNormalDistribution;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.DataSetPreProcessor;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.factory.Nd4j;
+
+/**
+ * This is an iterator which creates a parameterized mixture of gaussians
+ * for the purpose of verifying the convergence of a mixture-density
+ * loss function and its corresponding gradient.
+ * 
+ * @author Jonathan Arney
+ */
+public class GaussianMixtureIterator implements DataSetIterator {
+
+    private final int iterationsPerBatch = 32;
+    private final int miniBatchSize = 1000;
+    private final int numExamplesToFetch = iterationsPerBatch * miniBatchSize;
+    private int examplesSoFar = 0;
+    private final Random mRNG;
+    private final int mMixturesPerLabel;
+    
+    public GaussianMixtureIterator(int nMixturesPerLabel) {
+        mRNG = new Random();
+        mMixturesPerLabel = nMixturesPerLabel;
+    }
+    
+    @Override
+    public DataSet next() {
+        return next(miniBatchSize);
+    }
+
+    @Override
+    public boolean hasNext() {
+        return (examplesSoFar < numExamplesToFetch);
+    }
+
+    @Override
+    public DataSet next(int num) {
+        if (examplesSoFar + num > numExamplesToFetch) {
+            throw new NoSuchElementException();
+        }
+        try {
+            DataSet nextData = nextThrows(num);
+            examplesSoFar += num;
+            return nextData;
+        }
+        catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+    
+    public DataSet nextThrows(int num) throws Exception {
+        
+        INDArray input = Nd4j.zeros(num, inputColumns());
+        INDArray output = Nd4j.zeros(num, totalOutcomes());
+
+        for (int i = 0; i < num; i++) {
+            double x = mRNG.nextDouble() - 0.5;
+
+            // The effect of this is two two-dimensional gaussians
+            // mixed 50/50 with one another.
+            // The first gaussian is fixed with a mean of (-0.5, -0.5).
+            // The second gaussian has a mean that varies from -0.25 to 0.25.
+            // The variance of both is 0.01 (std-deviation 0.1)
+            
+            boolean mid = mRNG.nextBoolean();
+            double meanFactor = mid ? -0.5 : 0.5*x;
+            double sigma = mid ? 0.01 : 0.01;
+            
+            MultivariateNormalDistribution mnd = new MultivariateNormalDistribution(
+                    new double[] {1*meanFactor, 1*meanFactor},
+                    new double[][] {
+                        {sigma, 0.0},
+                        {0.0, sigma}
+                    }
+            );
+
+            double[] samples = mnd.sample();
+            
+            input.putScalar(new int[]{i, 0}, x*10);
+            output.putScalar(new int[]{i, 0}, samples[0]);
+            output.putScalar(new int[]{i, 1}, samples[1]);
+        }
+
+        
+        return new DataSet(input, output);
+    }
+
+    @Override
+    public int totalExamples() {
+        return numExamplesToFetch;
+    }
+
+    @Override
+    public int inputColumns() {
+        return 1;
+    }
+
+    @Override
+    public int totalOutcomes() {
+        return 2;
+    }
+
+    @Override
+    public boolean resetSupported() {
+        return true;
+    }
+
+    @Override
+    public boolean asyncSupported() {
+        return false;
+    }
+
+    @Override
+    public void reset() {
+        examplesSoFar = 0;
+    }
+
+    @Override
+    public int batch() {
+        return 1;
+    }
+
+    @Override
+    public int cursor() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public int numExamples() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public void setPreProcessor(DataSetPreProcessor preProcessor) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public DataSetPreProcessor getPreProcessor() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public List<String> getLabels() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    public static void main(String[] args) {
+        GaussianMixtureIterator it = new GaussianMixtureIterator(1);
+        
+        int j = 0;
+        while (it.hasNext()) {
+            if (j == 8) break;
+            DataSet next = it.next();
+            INDArray features = next.getFeatures();
+            INDArray labels = next.getLabels();
+            
+            for (int i = 0; i < features.rows(); i++) {
+                System.out.println("" + features.getDouble(i) + "\t" + labels.getDouble(i, 0));
+            }
+            j++;
+        }
+    }
+    
+    
+}

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/misc/lossfunctions/MixtureDensityNetwork.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/misc/lossfunctions/MixtureDensityNetwork.java
@@ -1,0 +1,179 @@
+package org.deeplearning4j.examples.misc.lossfunctions;
+
+import java.io.PrintStream;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Random;
+import org.deeplearning4j.nn.api.Model;
+import org.deeplearning4j.nn.api.OptimizationAlgorithm;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.Updater;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.conf.layers.RBM;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.nn.weights.WeightInit;
+import org.deeplearning4j.optimize.api.IterationListener;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.api.buffer.DataBuffer;
+import org.nd4j.linalg.api.buffer.util.DataTypeUtil;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.lossfunctions.impl.LossMixtureDensity;
+
+/**
+ * This is an example of using a mixture density network to learn the
+ * distribution of a dataset instead of trying to converge directly onto
+ * the dataset.  This is particularly useful when your data represents
+ * a mixture of multivariate gaussian distributions.  Traditional cost
+ * functions will converge on the mean of the dataset whereas a mixture
+ * density network will fit a series of gaussians to that dataset
+ * and extract the parameters "alpha" (relative strength of that gaussian),
+ * the "sigma" or "standard-deviation" of that gaussian, and "mu", the
+ * mean of that distribution.
+ * 
+ * For a more detailed explanation of this, see Christopher Bishop's paper.
+ *  
+ * Bishop CM. Mixture density networks,
+ * Neural Computing Research Group Report:
+ * NCRG/94/004, Aston University, Birmingham, 1994
+ * https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/bishop-ncrg-94-004.pdf
+ * 
+ * @author Jonathan Arney
+ */
+public class MixtureDensityNetwork {
+    public static void main(String[] args) {
+        
+        final int inputSize = 1;
+        final int outputLabels = 2;
+        
+        // Number of gaussian mixtures to
+        // attempt to fit.
+        final int mixturesToFit = 2;
+        
+        DataTypeUtil.setDTypeForContext(DataBuffer.Type.DOUBLE);
+        
+        final int hiddenLayerSize = 20 * mixturesToFit;
+        
+        Random rng = new Random();
+
+        NumberFormat formatter = new DecimalFormat("#0.0000");
+        LossMixtureDensity loss = LossMixtureDensity.builder()
+                            .gaussians(mixturesToFit)
+                            .labelWidth(outputLabels)
+                            .build();
+        
+        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+                .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT).iterations(1)
+                .learningRate(1e-2)
+                .rmsDecay(0.95)
+                .seed(rng.nextInt())
+                .weightInit(WeightInit.XAVIER)
+                .updater(Updater.RMSPROP)
+                .list()
+                .layer(0, new RBM.Builder()
+                        .nIn(inputSize)
+                        .nOut(hiddenLayerSize)
+                        .activation(Activation.TANH)
+                        .build())
+                .layer(1, new RBM.Builder()
+                        .nIn(hiddenLayerSize)
+                        .nOut(hiddenLayerSize)
+                        .activation(Activation.TANH)
+                        .build())
+                .layer(2, new OutputLayer.Builder()
+                        .nIn(hiddenLayerSize)
+                        .nOut(mixturesToFit * (2+outputLabels))
+                        .activation(Activation.IDENTITY)
+                        .lossFunction(loss)
+                        .build())
+                .pretrain(false).backprop(true)
+                .build();
+        MultiLayerNetwork net = new MultiLayerNetwork(conf);
+        net.init();
+        net.setListeners(new ScoreIterationListener(System.out));
+        
+        int trainingEpochs = 500;
+        
+        DataSetIterator iter = new GaussianMixtureIterator(mixturesToFit);
+        PrintStream logOutput = System.out;
+        
+        //Do training, and then generate and print samples from network
+        for (int i = 0; i < trainingEpochs; i++) {
+            logOutput.println("Epoch number " + i);
+            while (iter.hasNext()) {
+                DataSet ds = iter.next();
+                net.fit(ds);
+            }
+
+            iter.reset();	//Reset iterator for another epoch
+            
+            INDArray in = Nd4j.zeros(1);
+
+            // Output what the network
+            // has learned.  Go from -5 to 5
+            // and print out the gaussian mixtures.
+            for (int j = 0; j < 11; j++) {
+                double input = (.1 * j - 0.5)*10;
+                in.putScalar(0, input);
+                INDArray output = net.activateSelectedLayers(0, net.getnLayers()-1, in);
+
+                LossMixtureDensity.MixtureDensityComponents mixtures = loss.extractComponents(output);
+                
+                System.out.print("" + formatter.format(input) + "\t");
+                for (int mixtureNumber = 0; mixtureNumber < mixturesToFit; mixtureNumber++) {
+                    System.out.print("a" + mixtureNumber + " = " + formatter.format(mixtures.getAlpha().getDouble(0, mixtureNumber)) +
+                                     " s" + mixtureNumber + " = " + formatter.format(mixtures.getSigma().getDouble(0, mixtureNumber)) +
+                            " m" + mixtureNumber + " = ("
+                    );
+                    for (int labelNumber = 0;  labelNumber < outputLabels; labelNumber++) {
+                        if (labelNumber != 0) {
+                            System.out.print(",");
+                        }
+                        System.out.print( 
+                                formatter.format(mixtures.getMu().getDouble(0, mixtureNumber, labelNumber))
+                        );
+                    }
+                    System.out.print(") ");
+                }
+                System.out.println();
+            }
+        }
+    }
+    
+    public static class ScoreIterationListener implements IterationListener {
+        private long iterCount = 0;
+        private long lastSampleTime;
+        private final PrintStream logWriter;
+        /**
+         * @param writer Output writer.
+         */
+        public ScoreIterationListener(PrintStream writer) {
+            lastSampleTime = System.currentTimeMillis();
+            logWriter = writer;
+        }
+
+        @Override
+        public boolean invoked(){ return iterCount > 0;}
+
+        @Override
+        public void invoke() {
+            iterCount++;
+        }
+
+        @Override
+        public void iterationDone(Model model, int iteration) {
+            invoke();
+            double result = model.score();
+            long currentTime = System.currentTimeMillis();
+            if ((iterCount % 32) == 0) {
+                logWriter.println("Score at iteration " + iterCount + " is " + result + " took " + (currentTime - lastSampleTime) + " ms");
+                lastSampleTime = currentTime;
+            }
+        }
+    }
+    
+    
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

See also https://github.com/deeplearning4j/nd4j/issues/1859

The use of an MSE or L2 cost function means that the network will effectively converge on the mean of the dataset. For some datasets, this is not a desirable behavior and instead, one would like to find the parameters of the distribution of the data. In particular, it is often desirable to converge on a mixture of gaussian distributions which describe the statistical properties of the data.

For this purpose, nd4j should provide a Mixture Density loss function as described by Bishop[1994].
http://publications.aston.ac.uk/373/1/NCRG_94_004.pdf

## How was this patch tested?

Unit test was provided and a corresponding example (see PR for dl4j-examples) was used to verify the convergence of the loss function in a controlled setting.  Note that precision has NOT been verified on a CUDA platform because I lack the requisite hardware to test on that platform.  All testing was performed using the native-cpu platform under Ubuntu 16.04.

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
