### PR TITLE
Helps the removal of berkeley.Pair (do not merge)

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/feedforward/anomalydetection/VaeMNISTAnomaly.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/feedforward/anomalydetection/VaeMNISTAnomaly.java
@@ -1,6 +1,6 @@
 package org.deeplearning4j.examples.feedforward.anomalydetection;
 
-import org.deeplearning4j.berkeley.Pair;
+import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/feedforward/classification/detectgender/GenderRecordReader.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/feedforward/classification/detectgender/GenderRecordReader.java
@@ -20,7 +20,7 @@ import org.datavec.api.split.FileSplit;
 import org.datavec.api.split.InputSplit;
 import org.datavec.api.split.InputStreamInputSplit;
 import org.datavec.api.writable.Writable;
-import org.deeplearning4j.berkeley.Pair;
+import org.nd4j.linalg.primitives.Pair;
 
 
 /**

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/misc/centerloss/CenterLossLenetMnistExample.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/misc/centerloss/CenterLossLenetMnistExample.java
@@ -1,6 +1,6 @@
 package org.deeplearning4j.examples.misc.centerloss;
 
-import org.deeplearning4j.berkeley.Pair;
+import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator;
 import org.deeplearning4j.examples.unsupervised.variational.plot.PlotUtil;
 import org.deeplearning4j.examples.userInterface.util.GradientsAndParamsListener;

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/misc/customlayers/layer/CustomLayerImpl.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/misc/customlayers/layer/CustomLayerImpl.java
@@ -1,6 +1,6 @@
 package org.deeplearning4j.examples.misc.customlayers.layer;
 
-import org.deeplearning4j.berkeley.Pair;
+import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/misc/externalerrors/MultiLayerNetworkExternalErrors.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/misc/externalerrors/MultiLayerNetworkExternalErrors.java
@@ -1,6 +1,6 @@
 package org.deeplearning4j.examples.misc.externalerrors;
 
-import org.deeplearning4j.berkeley.Pair;
+import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.Updater;

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/nlp/paragraphvectors/ParagraphVectorsClassifierExample.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/nlp/paragraphvectors/ParagraphVectorsClassifierExample.java
@@ -1,7 +1,7 @@
 package org.deeplearning4j.examples.nlp.paragraphvectors;
 
 import org.datavec.api.util.ClassPathResource;
-import org.deeplearning4j.berkeley.Pair;
+import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.examples.nlp.paragraphvectors.tools.LabelSeeker;
 import org.deeplearning4j.examples.nlp.paragraphvectors.tools.MeansBuilder;
 import org.deeplearning4j.models.embeddings.inmemory.InMemoryLookupTable;

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/nlp/paragraphvectors/tools/LabelSeeker.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/nlp/paragraphvectors/tools/LabelSeeker.java
@@ -1,7 +1,7 @@
 package org.deeplearning4j.examples.nlp.paragraphvectors.tools;
 
 import lombok.NonNull;
-import org.deeplearning4j.berkeley.Pair;
+import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.models.embeddings.inmemory.InMemoryLookupTable;
 import org.deeplearning4j.models.word2vec.VocabWord;
 import org.nd4j.linalg.api.ndarray.INDArray;

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/nlp/tsne/TSNEStandardExample.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/nlp/tsne/TSNEStandardExample.java
@@ -1,7 +1,7 @@
 package org.deeplearning4j.examples.nlp.tsne;
 
 import org.datavec.api.util.ClassPathResource;
-import org.deeplearning4j.berkeley.Pair;
+import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.models.embeddings.inmemory.InMemoryLookupTable;
 import org.deeplearning4j.models.embeddings.loader.WordVectorSerializer;
 import org.deeplearning4j.models.word2vec.wordstore.VocabCache;
@@ -74,4 +74,3 @@ public class TSNEStandardExample {
 
 
 }
-

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/seqclassification/UCISequenceClassificationExample.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/seqclassification/UCISequenceClassificationExample.java
@@ -2,7 +2,7 @@ package org.deeplearning4j.examples.recurrent.seqclassification;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.datavec.api.berkeley.Pair;
+import org.nd4j.linalg.primitives.Pair;
 import org.datavec.api.records.reader.SequenceRecordReader;
 import org.datavec.api.records.reader.impl.csv.CSVSequenceRecordReader;
 import org.datavec.api.split.NumberedFileInputSplit;

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/unsupervised/variational/plot/PlotUtil.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/unsupervised/variational/plot/PlotUtil.java
@@ -1,6 +1,6 @@
 package org.deeplearning4j.examples.unsupervised.variational.plot;
 
-import org.deeplearning4j.berkeley.Pair;
+import org.nd4j.linalg.primitives.Pair;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
 import org.jfree.chart.JFreeChart;

--- a/lstm-hdfs/src/main/java/org/deeplearning4j/examples/StackSequenceRecordReader.java
+++ b/lstm-hdfs/src/main/java/org/deeplearning4j/examples/StackSequenceRecordReader.java
@@ -17,7 +17,7 @@ import org.apache.hadoop.fs.Path;
 import org.datavec.api.records.reader.impl.FileRecordReader;
 import org.datavec.api.records.reader.impl.csv.CSVSequenceRecordReader;
 import org.datavec.api.writable.Writable;
-import org.deeplearning4j.berkeley.Pair;
+import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.examples.conf.Constants;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.api.MultiDataSet;


### PR DESCRIPTION
See also deeplearning4j/deeplearning4j@4e42213
and al.


[Merge only just before triggering the release build : since the berkeley removal is published to 0.9.x-SNAPSHOT, this will only build if dependencies are replaced by some 0.9.x, which the release will do]
[also this depends on numerous 0.9.x-SNAPSHOT adaptations PRs]