### PR TITLE
Updated deprecated code across all examples directories.

### DIFF
--- a/dl4j-cuda-specific-examples/pom.xml
+++ b/dl4j-cuda-specific-examples/pom.xml
@@ -89,6 +89,11 @@
             <version>${dl4j.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.deeplearning4j</groupId>
+            <artifactId>deeplearning4j-zoo</artifactId>
+            <version>${dl4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.nd4j</groupId>
             <artifactId>${nd4j.backend}</artifactId>
         </dependency>

--- a/dl4j-cuda-specific-examples/src/main/java/org/deeplearning4j/examples/multigpu/vgg16/dataHelpers/FeaturizedPreSave.java
+++ b/dl4j-cuda-specific-examples/src/main/java/org/deeplearning4j/examples/multigpu/vgg16/dataHelpers/FeaturizedPreSave.java
@@ -6,6 +6,8 @@ import org.deeplearning4j.nn.modelimport.keras.UnsupportedKerasConfigurationExce
 import org.deeplearning4j.nn.modelimport.keras.trainedmodels.TrainedModelHelper;
 import org.deeplearning4j.nn.modelimport.keras.trainedmodels.TrainedModels;
 import org.deeplearning4j.nn.transferlearning.TransferLearningHelper;
+import org.deeplearning4j.zoo.ZooModel;
+import org.deeplearning4j.zoo.model.VGG16;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 import org.slf4j.Logger;
@@ -28,9 +30,9 @@ public class FeaturizedPreSave {
     public static void main(String [] args) throws UnsupportedKerasConfigurationException, IOException, InvalidKerasConfigurationException {
 
         //import org.deeplearning4j.transferlearning.vgg16 and print summary
-        TrainedModelHelper modelImportHelper = new TrainedModelHelper(TrainedModels.VGG16);
         LOGGER.info("\n\nLoading org.deeplearning4j.transferlearning.vgg16...\n\n");
-        ComputationGraph vgg16 = modelImportHelper.loadModel();
+        ZooModel zooModel = new VGG16();
+        ComputationGraph vgg16 = (ComputationGraph) zooModel.initPretrained();
         LOGGER.info(vgg16.summary());
 
         //use the TransferLearningHelper to freeze the specified vertices and below

--- a/dl4j-cuda-specific-examples/src/main/java/org/deeplearning4j/examples/multigpu/vgg16/dataHelpers/FlowerDataSetIterator.java
+++ b/dl4j-cuda-specific-examples/src/main/java/org/deeplearning4j/examples/multigpu/vgg16/dataHelpers/FlowerDataSetIterator.java
@@ -9,8 +9,8 @@ import org.datavec.api.util.ArchiveUtils;
 import org.datavec.image.loader.BaseImageLoader;
 import org.datavec.image.recordreader.ImageRecordReader;
 import org.deeplearning4j.datasets.datavec.RecordReaderDataSetIterator;
-import org.deeplearning4j.nn.modelimport.keras.trainedmodels.TrainedModels;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.dataset.api.preprocessor.VGG16ImagePreProcessor;
 import org.slf4j.Logger;
 
 import java.io.File;
@@ -76,7 +76,7 @@ public class FlowerDataSetIterator {
         ImageRecordReader recordReader = new ImageRecordReader(height,width,channels,labelMaker);
         recordReader.initialize(split);
         DataSetIterator iter = new RecordReaderDataSetIterator(recordReader, batchSize, 1, numClasses);
-        iter.setPreProcessor(TrainedModels.VGG16.getPreProcessor());
+        iter.setPreProcessor(new VGG16ImagePreProcessor());
         return iter;
     }
 

--- a/dl4j-cuda-specific-examples/src/main/java/org/deeplearning4j/examples/multigpu/vgg16/vgg16/FitFromFeaturized.java
+++ b/dl4j-cuda-specific-examples/src/main/java/org/deeplearning4j/examples/multigpu/vgg16/vgg16/FitFromFeaturized.java
@@ -8,13 +8,13 @@ import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.modelimport.keras.InvalidKerasConfigurationException;
 import org.deeplearning4j.nn.modelimport.keras.UnsupportedKerasConfigurationException;
-import org.deeplearning4j.nn.modelimport.keras.trainedmodels.TrainedModelHelper;
-import org.deeplearning4j.nn.modelimport.keras.trainedmodels.TrainedModels;
 import org.deeplearning4j.nn.transferlearning.FineTuneConfiguration;
 import org.deeplearning4j.nn.transferlearning.TransferLearning;
 import org.deeplearning4j.nn.transferlearning.TransferLearningHelper;
 import org.deeplearning4j.nn.weights.WeightInit;
 import org.deeplearning4j.parallelism.ParallelWrapper;
+import org.deeplearning4j.zoo.ZooModel;
+import org.deeplearning4j.zoo.model.VGG16;
 import org.nd4j.jita.conf.CudaEnvironment;
 import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
@@ -62,9 +62,9 @@ public class FitFromFeaturized {
         //Import vgg
         //Note that the model imported does not have an output layer (check printed summary)
         //  nor any training related configs (model from keras was imported with only weights and json)
-        TrainedModelHelper modelImportHelper = new TrainedModelHelper(TrainedModels.VGG16);
         log.info("\n\nLoading org.deeplearning4j.transferlearning.vgg16...\n\n");
-        ComputationGraph vgg16 = modelImportHelper.loadModel();
+        ZooModel zooModel = new VGG16();
+        ComputationGraph vgg16 = (ComputationGraph) zooModel.initPretrained();
         log.info(vgg16.summary());
 
         //Decide on a fine tune configuration to use.

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/transferlearning/vgg16/dataHelpers/FlowerDataSetIterator.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/transferlearning/vgg16/dataHelpers/FlowerDataSetIterator.java
@@ -9,8 +9,8 @@ import org.datavec.api.util.ArchiveUtils;
 import org.datavec.image.loader.BaseImageLoader;
 import org.datavec.image.recordreader.ImageRecordReader;
 import org.deeplearning4j.datasets.datavec.RecordReaderDataSetIterator;
-import org.deeplearning4j.nn.modelimport.keras.trainedmodels.TrainedModels;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.dataset.api.preprocessor.VGG16ImagePreProcessor;
 import org.slf4j.Logger;
 
 import java.io.File;
@@ -76,7 +76,7 @@ public class FlowerDataSetIterator {
         ImageRecordReader recordReader = new ImageRecordReader(height,width,channels,labelMaker);
         recordReader.initialize(split);
         DataSetIterator iter = new RecordReaderDataSetIterator(recordReader, batchSize, 1, numClasses);
-        iter.setPreProcessor(TrainedModels.VGG16.getPreProcessor());
+        iter.setPreProcessor( new VGG16ImagePreProcessor());
         return iter;
     }
 

--- a/dl4j-spark-examples/dl4j-spark/src/main/java/org/deeplearning4j/transferlearning/vgg16/FitFromFeaturized.java
+++ b/dl4j-spark-examples/dl4j-spark/src/main/java/org/deeplearning4j/transferlearning/vgg16/FitFromFeaturized.java
@@ -18,8 +18,6 @@ import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.modelimport.keras.InvalidKerasConfigurationException;
 import org.deeplearning4j.nn.modelimport.keras.UnsupportedKerasConfigurationException;
-import org.deeplearning4j.nn.modelimport.keras.trainedmodels.TrainedModelHelper;
-import org.deeplearning4j.nn.modelimport.keras.trainedmodels.TrainedModels;
 import org.deeplearning4j.nn.transferlearning.FineTuneConfiguration;
 import org.deeplearning4j.nn.transferlearning.TransferLearning;
 import org.deeplearning4j.nn.transferlearning.TransferLearningHelper;
@@ -27,6 +25,8 @@ import org.deeplearning4j.nn.weights.WeightInit;
 import org.deeplearning4j.spark.api.TrainingMaster;
 import org.deeplearning4j.spark.impl.graph.SparkComputationGraph;
 import org.deeplearning4j.spark.impl.paramavg.ParameterAveragingTrainingMaster;
+import org.deeplearning4j.zoo.ZooModel;
+import org.deeplearning4j.zoo.model.VGG16;
 import org.deeplearning4j.transferlearning.vgg16.dataHelpers.FeaturizedPreSave;
 import org.deeplearning4j.transferlearning.vgg16.dataHelpers.FlowerDataSetIteratorFeaturized;
 import org.nd4j.linalg.activations.Activation;
@@ -94,9 +94,9 @@ public class FitFromFeaturized {
         //Import vgg
         //Note that the model imported does not have an output layer (check printed summary)
         //  nor any training related configs (model from keras was imported with only weights and json)
-        TrainedModelHelper modelImportHelper = new TrainedModelHelper(TrainedModels.VGG16);
         log.info("\n\nLoading org.deeplearning4j.transferlearning.vgg16...\n\n");
-        ComputationGraph vgg16 = modelImportHelper.loadModel();
+        ZooModel zooModel = new VGG16();
+        ComputationGraph vgg16 = (ComputationGraph) zooModel.initPretrained();
         log.info(vgg16.summary());
         //Decide on a fine tune configuration to use.
         //In cases where there already exists a setting the fine tune setting will

--- a/dl4j-spark-examples/dl4j-spark/src/main/java/org/deeplearning4j/transferlearning/vgg16/dataHelpers/FeaturizedPreSave.java
+++ b/dl4j-spark-examples/dl4j-spark/src/main/java/org/deeplearning4j/transferlearning/vgg16/dataHelpers/FeaturizedPreSave.java
@@ -4,9 +4,9 @@ import org.apache.spark.SparkConf;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.modelimport.keras.InvalidKerasConfigurationException;
 import org.deeplearning4j.nn.modelimport.keras.UnsupportedKerasConfigurationException;
-import org.deeplearning4j.nn.modelimport.keras.trainedmodels.TrainedModelHelper;
-import org.deeplearning4j.nn.modelimport.keras.trainedmodels.TrainedModels;
 import org.deeplearning4j.nn.transferlearning.TransferLearningHelper;
+import org.deeplearning4j.zoo.ZooModel;
+import org.deeplearning4j.zoo.model.VGG16;
 import org.nd4j.linalg.dataset.DataSet;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
 import org.slf4j.Logger;
@@ -30,9 +30,9 @@ public class FeaturizedPreSave {
     public static void main(String [] args) throws UnsupportedKerasConfigurationException, IOException, InvalidKerasConfigurationException {
 
         //import org.deeplearning4j.transferlearning.vgg16 and print summary
-        TrainedModelHelper modelImportHelper = new TrainedModelHelper(TrainedModels.VGG16);
         LOGGER.info("\n\nLoading org.deeplearning4j.transferlearning.vgg16...\n\n");
-        ComputationGraph vgg16 = modelImportHelper.loadModel();
+        ZooModel zooModel = new VGG16();
+        ComputationGraph vgg16 = (ComputationGraph) zooModel.initPretrained();
         LOGGER.info(vgg16.summary());
 
         //use the TransferLearningHelper to freeze the specified vertices and below

--- a/dl4j-spark-examples/dl4j-spark/src/main/java/org/deeplearning4j/transferlearning/vgg16/dataHelpers/FlowerDataSetIterator.java
+++ b/dl4j-spark-examples/dl4j-spark/src/main/java/org/deeplearning4j/transferlearning/vgg16/dataHelpers/FlowerDataSetIterator.java
@@ -11,6 +11,7 @@ import org.datavec.image.recordreader.ImageRecordReader;
 import org.deeplearning4j.datasets.datavec.RecordReaderDataSetIterator;
 import org.deeplearning4j.nn.modelimport.keras.trainedmodels.TrainedModels;
 import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.dataset.api.preprocessor.VGG16ImagePreProcessor;
 import org.slf4j.Logger;
 
 import java.io.File;
@@ -76,7 +77,7 @@ public class FlowerDataSetIterator {
         ImageRecordReader recordReader = new ImageRecordReader(height,width,channels,labelMaker);
         recordReader.initialize(split);
         DataSetIterator iter = new RecordReaderDataSetIterator(recordReader, batchSize, 1, numClasses);
-        iter.setPreProcessor(TrainedModels.VGG16.getPreProcessor());
+        iter.setPreProcessor(new VGG16ImagePreProcessor());
         return iter;
     }
 

--- a/dl4j-spark-examples/pom.xml
+++ b/dl4j-spark-examples/pom.xml
@@ -18,5 +18,12 @@
         <module>dl4j-spark</module>
     </modules>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.deeplearning4j</groupId>
+            <artifactId>deeplearning4j-zoo</artifactId>
+            <version>${dl4j.version}</version>
+        </dependency>
+    </dependencies>
 
 </project>


### PR DESCRIPTION
Updated deprecated code across all examples directories.
One deprecated line form dl4j-examples slipped through.
resolves #524

## How was this patch tested?
Everything run manually in dl4j-examples. 'It compiled' for the other directories.
