### PR TITLE
dl4j-examples : mvn clean install terminates due to eror in dl4j-cuda-specific-example pom.xml

### DIFF
--- a/dl4j-cuda-specific-examples/pom.xml
+++ b/dl4j-cuda-specific-examples/pom.xml
@@ -89,11 +89,6 @@
             <version>${dl4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.deeplearning4j</groupId>
-            <artifactId>deeplearning4j-zoo</artifactId>
-            <version>${dl4j.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.nd4j</groupId>
             <artifactId>${nd4j.backend}</artifactId>
         </dependency>


### PR DESCRIPTION
dl4j-examples mvn clean install terminates due to eror in dl4j-cuda-specific-example pom.xml

## What changes were proposed in this pull request?

I just removed the content because it is duplicated, below, from pom.xml and it is resolved :

```
<dependency> 
        <groupId>org.deeplearning4j</groupId> 
        <artifactId>deeplearning4j-zoo</artifactId> 
        <version>${dl4j.version}</version> 
</dependency> 
```

## How was this patch tested?

manually tested

```
[INFO] Reactor Summary:
[INFO]
[INFO] DeepLearning4j Examples Parent ..................... SUCCESS [ 11.232 s]
[INFO] DeepLearning4j Examples ............................ SUCCESS [02:38 min]
[INFO] dl4j-spark-examples ................................ SUCCESS [  0.409 s]
[INFO] dl4j-spark ......................................... SUCCESS [01:48 min]
[INFO] datavec-examples ................................... SUCCESS [ 24.655 s]
[INFO] DeepLearning4j CUDA special examples ............... SUCCESS [01:44 min]
[INFO] nd4j-examples ...................................... SUCCESS [  4.304 s]
[INFO] Reinforcement Learning4j Examples .................. SUCCESS [01:25 min]
[INFO] lstm-hdfs .......................................... SUCCESS [  1.763 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 08:19 min
[INFO] Finished at: 2017-10-27T09:59:45+03:00
[INFO] Final Memory: 105M/816M
[INFO] ------------------------------------------------------------------------
```

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
