### PR TITLE
Vectorize wordvector generation

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/word2vecsentiment/Word2VecSentimentRNN.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/word2vecsentiment/Word2VecSentimentRNN.java
@@ -67,11 +67,13 @@ public class Word2VecSentimentRNN {
         int vectorSize = 300;   //Size of the word vectors. 300 in the Google News model
         int nEpochs = 1;        //Number of epochs (full passes of training data) to train on
         int truncateReviewsToLength = 256;  //Truncate reviews with length (# words) greater than this
+        final int seed = 0;     //Seed for reproducibility
 
         Nd4j.getMemoryManager().setAutoGcWindow(10000);  //https://deeplearning4j.org/workspaces
 
         //Set up network configuration
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+            .seed(seed)
             .updater(Updater.ADAM)  //To configure: .updater(Adam.builder().beta1(0.9).beta2(0.999).build())
             .regularization(true).l2(1e-5)
             .weightInit(WeightInit.XAVIER)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch vectorizes the feature generation in the `SentimentExampleIterator` to improve the performance and show how to generate features in a vectorized manner instead of element-wise.

## How was this patch tested?

This change patch was tested with [this gist](https://gist.github.com/slang03/11951b2f5e6fc35ab84fee3d2e37dc2a).

To ensure there is an actual performance improvement, [this gist](https://gist.github.com/slang03/ba4695dc0ae28f51f557bd711ccc746e) was run, comparing element-wise wordvector feature generation with the vectorized version. Both versions were run 100 times for batch sizes in `[2^4, ..., 2^9]`. On average the vectorized version was ~ 2-3 times faster than the elementwise. Results may vary on different machines. 