### PR TITLE
better results with 'nearestSum' in W2V examples

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/nlp/word2vec/Word2VecRawTextExample.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/nlp/word2vec/Word2VecRawTextExample.java
@@ -59,8 +59,8 @@ public class Word2VecRawTextExample {
 
         // Prints out the closest 10 words to "day". An example on what to do with these Word Vectors.
         log.info("Closest Words:");
-        Collection<String> lst = vec.wordsNearest("day", 10);
-        System.out.println("10 Words closest to 'day': " + lst);
+        Collection<String> lst = vec.wordsNearestSum("day", 10);
+        log.info("10 Words closest to 'day': {}", lst);
 
         // TODO resolve missing UiServer
 //        UiServer server = UiServer.getInstance();

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/nlp/word2vec/Word2VecUptrainingExample.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/nlp/word2vec/Word2VecUptrainingExample.java
@@ -100,7 +100,7 @@ public class Word2VecUptrainingExample {
 
         word2Vec.fit();
 
-        lst = word2Vec.wordsNearest("day", 10);
+        lst = word2Vec.wordsNearestSum("day", 10);
         log.info("Closest words to 'day' on 2nd run: " + lst);
 
         /*


### PR DESCRIPTION
## What changes were proposed in this pull request?

In W2V examples it seems that using 'wordsNearestSum' instead of 'wordsNearest' gives slightly better results:

- wordsNearest: [night, week, game, year, season, group, time, office, program, set]
- wordsNearestSum: [day, week, night, year, game, season, time, years, while, two]   

I have also successfully tried this with the [Billboard HOT100 dataset](http://kaylinwalker.com/50-years-of-pop-music).

## How was this patch tested?

Manual test running the examples 51 and 52.
