### PR TITLE
MnistClassifier example with 99% accuracy and test console

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/convolution/mnist/MnistClassifier.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/convolution/mnist/MnistClassifier.java
@@ -1,0 +1,161 @@
+package org.deeplearning4j.examples.convolution.mnist;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import org.datavec.api.io.labels.ParentPathLabelGenerator;
+import org.datavec.api.split.FileSplit;
+import org.datavec.image.loader.NativeImageLoader;
+import org.datavec.image.recordreader.ImageRecordReader;
+import org.deeplearning4j.datasets.datavec.RecordReaderDataSetIterator;
+import org.deeplearning4j.eval.Evaluation;
+import org.deeplearning4j.examples.utilities.DataUtilities;
+import org.deeplearning4j.nn.api.OptimizationAlgorithm;
+import org.deeplearning4j.nn.conf.LearningRatePolicy;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.Updater;
+import org.deeplearning4j.nn.conf.inputs.InputType;
+import org.deeplearning4j.nn.conf.layers.ConvolutionLayer;
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.conf.layers.SubsamplingLayer;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.nn.weights.WeightInit;
+import org.deeplearning4j.optimize.listeners.ScoreIterationListener;
+import org.deeplearning4j.util.ModelSerializer;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.dataset.api.preprocessor.DataNormalization;
+import org.nd4j.linalg.dataset.api.preprocessor.ImagePreProcessingScaler;
+import org.nd4j.linalg.lossfunctions.LossFunctions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handwritten digits image classification on MNIST dataset (99% accuracy).
+ * This example will download 15 Mb of data on the first run.
+ * Supervised learning best modeled by CNN.
+ *
+ * @author hanlon
+ * @author agibsonccc
+ * @author fvaleri
+ */
+public class MnistClassifier {
+
+  private static final Logger log = LoggerFactory.getLogger(MnistClassifier.class);
+  private static final String basePath = System.getProperty("java.io.tmpdir") + "/mnist";
+  private static final String dataUrl = "http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz";
+
+  public static void main(String[] args) throws Exception {
+    int height = 28;
+    int width = 28;
+    int channels = 1; // single channel for grayscale images
+    int outputNum = 10; // 10 digits classification
+    int batchSize = 54;
+    int nEpochs = 1;
+    int iterations = 1;
+
+    int seed = 1234;
+    Random randNumGen = new Random(seed);
+
+    log.info("Data load and vectorization...");
+    String localFilePath = basePath + "/mnist_png.tar.gz";
+    if (!DataUtilities.downloadFile(dataUrl, localFilePath))
+      log.info("Data file is already there");
+    if (!new File(basePath + "/mnist_png").exists())
+      DataUtilities.extractTarGz(localFilePath, basePath);
+
+    // vectorization of train data
+    File trainData = new File(basePath + "/mnist_png/training");
+    FileSplit trainSplit = new FileSplit(trainData, NativeImageLoader.ALLOWED_FORMATS, randNumGen);
+    ParentPathLabelGenerator labelMaker = new ParentPathLabelGenerator(); // parent path as the image label
+    ImageRecordReader trainRR = new ImageRecordReader(height, width, channels, labelMaker);
+    trainRR.initialize(trainSplit);
+    DataSetIterator trainIter = new RecordReaderDataSetIterator(trainRR, batchSize, 1, outputNum);
+
+    // pixel values scaling from 0-255 to 0-1
+    DataNormalization scaler = new ImagePreProcessingScaler(0, 1);
+    scaler.fit(trainIter);
+    trainIter.setPreProcessor(scaler);
+
+    // vectorization of test data
+    File testData = new File(basePath + "/mnist_png/testing");
+    FileSplit testSplit = new FileSplit(testData, NativeImageLoader.ALLOWED_FORMATS, randNumGen);
+    ImageRecordReader testRR = new ImageRecordReader(height, width, channels, labelMaker);
+    testRR.initialize(testSplit);
+    DataSetIterator testIter = new RecordReaderDataSetIterator(testRR, batchSize, 1, outputNum);
+    testIter.setPreProcessor(scaler); // same normalization for better results
+
+    log.info("Network configuration and training...");
+    Map<Integer, Double> lrSchedule = new HashMap<>();
+    lrSchedule.put(0, 0.06); // iteration #, learning rate
+    lrSchedule.put(300, 0.05);
+    lrSchedule.put(500, 0.029);
+    lrSchedule.put(700, 0.0043);
+    lrSchedule.put(1000, 0.001);
+
+    MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+        .seed(seed)
+        .iterations(iterations)
+        .regularization(true).l2(0.0005)
+        .learningRate(.01)
+        .learningRateDecayPolicy(LearningRatePolicy.Schedule)
+        .learningRateSchedule(lrSchedule) // overrides the rate set in learningRate
+        .weightInit(WeightInit.XAVIER)
+        .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+        .updater(Updater.NESTEROVS)
+        .list()
+        .layer(0, new ConvolutionLayer.Builder(5, 5)
+            .nIn(channels)
+            .stride(1, 1)
+            .nOut(20)
+            .activation(Activation.IDENTITY)
+            .build())
+        .layer(1, new SubsamplingLayer.Builder(SubsamplingLayer.PoolingType.MAX)
+            .kernelSize(2, 2)
+            .stride(2, 2)
+            .build())
+        .layer(2, new ConvolutionLayer.Builder(5, 5)
+            .stride(1, 1) // nIn need not specified in later layers
+            .nOut(50)
+            .activation(Activation.IDENTITY)
+            .build())
+        .layer(3, new SubsamplingLayer.Builder(SubsamplingLayer.PoolingType.MAX)
+            .kernelSize(2, 2)
+            .stride(2, 2)
+            .build())
+        .layer(4, new DenseLayer.Builder().activation(Activation.RELU)
+            .nOut(500).build())
+        .layer(5, new OutputLayer.Builder(LossFunctions.LossFunction.NEGATIVELOGLIKELIHOOD)
+            .nOut(outputNum)
+            .activation(Activation.SOFTMAX)
+            .build())
+        .setInputType(InputType.convolutionalFlat(28, 28, 1)) // InputType.convolutional for normal image
+        .backprop(true).pretrain(false).build();
+
+    MultiLayerNetwork net = new MultiLayerNetwork(conf);
+    net.init();
+    net.setListeners(new ScoreIterationListener(10));
+
+    log.debug("Total num of params: {}", net.numParams());
+    for (int i = 0; i < net.getnLayers(); i++) {
+      log.debug("Layer {}, num of params: {}", i, net.getLayer(i).numParams());
+    }
+
+    // evaluation while training (the error/score should go down)
+    for (int i = 0; i < nEpochs; i++) {
+      net.fit(trainIter);
+      log.info("Completed epoch {}", i);
+      Evaluation eval = net.evaluate(testIter);
+      log.info(eval.stats());
+      trainIter.reset();
+      testIter.reset();
+    }
+
+    ModelSerializer.writeModel(net, new File(basePath + "/minist-model.zip"), true);
+  }
+
+}

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/convolution/mnist/MnistClassifierUI.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/convolution/mnist/MnistClassifierUI.java
@@ -1,0 +1,137 @@
+package org.deeplearning4j.examples.convolution.mnist;
+
+import java.awt.Graphics;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import org.datavec.image.loader.NativeImageLoader;
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.util.ModelSerializer;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dataset.api.preprocessor.ImagePreProcessingScaler;
+
+import javafx.application.Application;
+import javafx.embed.swing.SwingFXUtils;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.control.Label;
+import javafx.scene.image.ImageView;
+import javafx.scene.image.WritableImage;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.StrokeLineCap;
+import javafx.stage.Stage;
+
+/**
+ * Test UI for MNIST classifier.
+ * Run the MnistClassifier first to build the model.
+ *
+ * @author jesuino
+ * @author fvaleri
+ */
+@SuppressWarnings("restriction")
+public class MnistClassifierUI extends Application {
+
+  private static final String basePath = System.getProperty("java.io.tmpdir") + "/mnist";
+  private final int canvasWidth = 150;
+  private final int canvasHeight = 150;
+  private MultiLayerNetwork net; // trained model
+
+  public MnistClassifierUI() throws IOException {
+    File model = new File(basePath + "/minist-model.zip");
+    if (!model.exists())
+      throw new IOException("Can't find the model");
+    net = ModelSerializer.restoreMultiLayerNetwork(model);
+  }
+
+  public static void main(String[] args) throws Exception {
+    launch();
+  }
+
+  @Override
+  public void start(Stage stage) throws Exception {
+    Canvas canvas = new Canvas(canvasWidth, canvasHeight);
+    GraphicsContext ctx = canvas.getGraphicsContext2D();
+
+    ImageView imgView = new ImageView();
+    imgView.setFitHeight(100);
+    imgView.setFitWidth(100);
+    ctx.setLineWidth(10);
+    ctx.setLineCap(StrokeLineCap.SQUARE);
+    Label lblResult = new Label();
+
+    HBox hbBottom = new HBox(10, imgView, lblResult);
+    hbBottom.setAlignment(Pos.CENTER);
+    VBox root = new VBox(5, canvas, hbBottom);
+    root.setAlignment(Pos.CENTER);
+
+    Scene scene = new Scene(root, 520, 300);
+    stage.setScene(scene);
+    stage.setTitle("Draw a digit and hit enter (right-click to clear)");
+    stage.setResizable(false);
+    stage.show();
+
+    canvas.setOnMousePressed(e -> {
+      ctx.setStroke(Color.WHITE);
+      ctx.beginPath();
+      ctx.moveTo(e.getX(), e.getY());
+      ctx.stroke();
+    });
+    canvas.setOnMouseDragged(e -> {
+      ctx.setStroke(Color.WHITE);
+      ctx.lineTo(e.getX(), e.getY());
+      ctx.stroke();
+    });
+    canvas.setOnMouseClicked(e -> {
+      if (e.getButton() == MouseButton.SECONDARY) {
+        clear(ctx);
+      }
+    });
+    canvas.setOnKeyReleased(e -> {
+      if (e.getCode() == KeyCode.ENTER) {
+        BufferedImage scaledImg = getScaledImage(canvas);
+        imgView.setImage(SwingFXUtils.toFXImage(scaledImg, null));
+        try {
+          predictImage(scaledImg, lblResult);
+        } catch (Exception e1) {
+          e1.printStackTrace();
+        }
+      }
+    });
+    clear(ctx);
+    canvas.requestFocus();
+  }
+
+  private void clear(GraphicsContext ctx) {
+    ctx.setFill(Color.BLACK);
+    ctx.fillRect(0, 0, 300, 300);
+  }
+
+  private BufferedImage getScaledImage(Canvas canvas) {
+    WritableImage writableImage = new WritableImage(canvasWidth, canvasHeight);
+    canvas.snapshot(null, writableImage);
+    Image tmp = SwingFXUtils.fromFXImage(writableImage, null).getScaledInstance(28, 28, Image.SCALE_SMOOTH);
+    BufferedImage scaledImg = new BufferedImage(28, 28, BufferedImage.TYPE_BYTE_GRAY);
+    Graphics graphics = scaledImg.getGraphics();
+    graphics.drawImage(tmp, 0, 0, null);
+    graphics.dispose();
+    return scaledImg;
+  }
+
+  private void predictImage(BufferedImage img, Label lbl) throws IOException {
+    NativeImageLoader loader = new NativeImageLoader(28, 28, 1, true);
+    INDArray image = loader.asRowVector(img);
+    ImagePreProcessingScaler scaler = new ImagePreProcessingScaler(0, 1);
+    scaler.transform(image);
+    INDArray output = net.output(image);
+    lbl.setText("Prediction: " + net.predict(image)[0] + "\n " + output);
+  }
+
+}

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExample.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExample.java
@@ -1,13 +1,6 @@
 package org.deeplearning4j.examples.dataexamples;
 
-
-
 import org.apache.commons.io.FilenameUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.datavec.api.io.labels.ParentPathLabelGenerator;
 import org.datavec.api.records.listener.impl.LogRecordListener;
 import org.datavec.api.split.FileSplit;
@@ -30,196 +23,152 @@ import java.util.Random;
  * This code example is featured in this youtube video
  * https://www.youtube.com/watch?v=GLC8CIoHDnI
  *
- * This differs slightly from the Video Example,
+ * This differs slightly from the Video Example
  * The Video example had the data already downloaded
  * This example includes code that downloads the data
  *
- * Instructions
- * Downloads a directory containing a testing and a training folder
- * each folder has 10 directories 0-9
- * in each directory are 28 * 28 grayscale pngs of handwritten digits
+ * The Data Directory mnist_png will have two child directories training and testing
  * The training and testing directories will have directories 0-9 with
  * 28 * 28 PNG images of handwritten images
  *
  * The code here shows how to use a ParentPathLabelGenerator to label the images as
  * they are read into the RecordReader
  *
- * The pixel values are scaled to values between 0 and 1 using
- *  ImagePreProcessingScaler
+ * The pixel values are scaled to values between 0 and 1 using ImagePreProcessingScaler
  *
- *  In this example a loop steps through 3 images and prints the DataSet to
- *  the terminal. The expected output is the 28* 28 matrix of scaled pixel values
- *  the list with the label for that image
- *  and a list of the label values
+ * In this example a loop steps through 3 images and prints the DataSet to
+ * the terminal. The expected output is the 28* 28 matrix of scaled pixel values
+ * the list with the label for that image and a list of the label values
  *
- *  This example also applies a Listener to the RecordReader that logs the path of each image read
- *  You would not want to do this in production
- *  The reason it is done here is to show that a handwritten image 3 (for example)
- *  was read from directory 3,
- *  has a matrix with the shown values
- *  Has a label value corresponding to 3
- *
+ * This example also applies a Listener to the RecordReader that logs the path of each image read
+ * You would not want to do this in production. The reason it is done here is to show that a 
+ * handwritten image 3 (for example) was read from directory 3, has a matrix with the shown values,
+ * has a label value corresponding to 3
  */
-
 public class MnistImagePipelineExample {
+  private static Logger log = LoggerFactory.getLogger(MnistImagePipelineExample.class);
 
-    /** Data URL for downloading */
-    public static final String DATA_URL = "http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz";
+  /** Data URL for downloading */
+  public static final String DATA_URL = "http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz";
 
-    /** Location to save and extract the training/testing data */
-    public static final String DATA_PATH = FilenameUtils.concat(System.getProperty("java.io.tmpdir"), "dl4j_Mnist/");
+  /** Location to save and extract the training/testing data */
+  public static final String DATA_PATH = FilenameUtils.concat(System.getProperty("java.io.tmpdir"), "dl4j_Mnist/");
 
-
-
-    private static Logger log = LoggerFactory.getLogger(MnistImagePipelineExample.class);
-
-    public static void main(String[] args) throws Exception {
-        /*
-        image information
-        28 * 28 grayscale
-        grayscale implies single channel
-        */
-        int height = 28;
-        int width = 28;
-        int channels = 1;
-        int rngseed = 123;
-        Random randNumGen = new Random(rngseed);
-        int batchSize = 1;
-        int outputNum = 10;
-
-
-
-        /*
-        This class downloadData() downloads the data
-        stores the data in java's tmpdir
-        15MB download compressed
-        It will take 158MB of space when uncompressed
-        The data can be downloaded manually here
-        http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
-         */
-
-
-        downloadData();
-
-        // Define the File Paths
-        File trainData = new File(DATA_PATH + "/mnist_png/training");
-        File testData = new File(DATA_PATH + "/mnist_png/testing");
-
-        // Define the FileSplit(PATH, ALLOWED FORMATS,random)
-
-
-        FileSplit train = new FileSplit(trainData, NativeImageLoader.ALLOWED_FORMATS, randNumGen);
-        FileSplit test = new FileSplit(testData, NativeImageLoader.ALLOWED_FORMATS, randNumGen);
-
-        // Extract the parent path as the image label
-
-        ParentPathLabelGenerator labelMaker = new ParentPathLabelGenerator();
-
-        ImageRecordReader recordReader = new ImageRecordReader(height, width, channels, labelMaker);
-
-        // Initialize the record reader
-        // add a listener, to extract the name
-
-        recordReader.initialize(train);
-
-        // The LogRecordListener will log the path of each image read
-        // used here for information purposes,
-        // If the whole dataset was ingested this would place 60,000
-        // lines in our logs
-        // It will show up in the output with this format
-        // o.d.a.r.l.i.LogRecordListener - Reading /tmp/mnist_png/training/4/36384.png
-
-        recordReader.setListeners(new LogRecordListener());
-
-        // DataSet Iterator
-
-        DataSetIterator dataIter = new RecordReaderDataSetIterator(recordReader, batchSize, 1, outputNum);
-
-        // Scale pixel values to 0-1
-
-        DataNormalization scaler = new ImagePreProcessingScaler(0, 1);
-        scaler.fit(dataIter);
-        dataIter.setPreProcessor(scaler);
-
-        // In production you would loop through all the data
-        // in this example the loop is just through 3
-        // images for demonstration purposes
-        for (int i = 1; i < 3; i++) {
-            DataSet ds = dataIter.next();
-            System.out.println(ds);
-            System.out.println(dataIter.getLabels());
-
-        }
-
-    }
+  public static void main(String[] args) throws Exception {
+    /*
+    image information
+    28 * 28 grayscale
+    grayscale implies single channel
+    */
+    int height = 28;
+    int width = 28;
+    int channels = 1;
+    int rngseed = 123;
+    Random randNumGen = new Random(rngseed);
+    int batchSize = 1;
+    int outputNum = 10;
 
     /*
-    Everything below here has nothing to do with your RecordReader,
-    or DataVec, or your Neural Network
-    The classes downloadData, getMnistPNG(),
-    and extractTarGz are for downloading and extracting the data
-     */
+    This class downloadData() downloads the data
+    stores the data in java's tmpdir 15MB download compressed
+    It will take 158MB of space when uncompressed
+    The data can be downloaded manually here
+    http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
+    */
+    downloadData();
 
-    private static void downloadData() throws Exception {
-        //Create directory if required
-        File directory = new File(DATA_PATH);
-        if(!directory.exists()) directory.mkdir();
+    // Define the File Paths
+    File trainData = new File(DATA_PATH + "/mnist_png/training");
 
-        //Download file:
-        String archizePath = DATA_PATH + "/mnist_png.tar.gz";
-        File archiveFile = new File(archizePath);
-        String extractedPath = DATA_PATH + "mnist_png";
-        File extractedFile = new File(extractedPath);
+    // Define the FileSplit(PATH, ALLOWED FORMATS,random)
+    FileSplit train = new FileSplit(trainData, NativeImageLoader.ALLOWED_FORMATS, randNumGen);
 
-        if( !archiveFile.exists() ){
-            System.out.println("Starting data download (15MB)...");
-            getMnistPNG();
-            //Extract tar.gz file to output directory
-            DataUtilities.extractTarGz(archizePath, DATA_PATH);
-        } else {
-            //Assume if archive (.tar.gz) exists, then data has already been extracted
-            System.out.println("Data (.tar.gz file) already exists at " + archiveFile.getAbsolutePath());
-            if( !extractedFile.exists()){
-                //Extract tar.gz file to output directory
-                DataUtilities.extractTarGz(archizePath, DATA_PATH);
-            } else {
-                System.out.println("Data (extracted) already exists at " + extractedFile.getAbsolutePath());
-            }
-        }
+    // Extract the parent path as the image label
+    ParentPathLabelGenerator labelMaker = new ParentPathLabelGenerator();
+
+    ImageRecordReader recordReader = new ImageRecordReader(height, width, channels, labelMaker);
+
+    // Initialize the record reader
+    // add a listener, to extract the name
+    recordReader.initialize(train);
+
+    // The LogRecordListener will log the path of each image read
+    // used here for information purposes,
+    // If the whole dataset was ingested this would place 60,000
+    // lines in our logs
+    // It will show up in the output with this format
+    // o.d.a.r.l.i.LogRecordListener - Reading /tmp/mnist_png/training/4/36384.png
+    recordReader.setListeners(new LogRecordListener());
+
+    // DataSet Iterator
+    DataSetIterator dataIter = new RecordReaderDataSetIterator(recordReader, batchSize, 1, outputNum);
+
+    // Scale pixel values to 0-1
+    DataNormalization scaler = new ImagePreProcessingScaler(0, 1);
+    scaler.fit(dataIter);
+    dataIter.setPreProcessor(scaler);
+
+    // In production you would loop through all the data
+    // in this example the loop is just through 3
+    // images for demonstration purposes
+    for (int i = 1; i < 3; i++) {
+      DataSet ds = dataIter.next();
+      log.info(ds.toString());
+      log.info(dataIter.getLabels().toString());
+    }
+  }
+
+  /*
+  Everything below here has nothing to do with your RecordReader,
+  or DataVec, or your Neural Network
+  The classes downloadData, getMnistPNG(),
+  and extractTarGz are for downloading and extracting the data
+  */
+
+  protected static void downloadData() throws Exception {
+    // Create directory if required
+    File directory = new File(DATA_PATH);
+    if (!directory.exists())
+      directory.mkdir();
+
+    // Download file:
+    String archizePath = DATA_PATH + "/mnist_png.tar.gz";
+    File archiveFile = new File(archizePath);
+    String extractedPath = DATA_PATH + "mnist_png";
+    File extractedFile = new File(extractedPath);
+
+    if (!archiveFile.exists()) {
+      log.info("Starting data download (15MB)...");
+      getMnistPNG();
+      //Extract tar.gz file to output directory
+      DataUtilities.extractTarGz(archizePath, DATA_PATH);
+    } else {
+      //Assume if archive (.tar.gz) exists, then data has already been extracted
+      log.info("Data (.tar.gz file) already exists at {}", archiveFile.getAbsolutePath());
+      if (!extractedFile.exists()) {
+        //Extract tar.gz file to output directory
+        DataUtilities.extractTarGz(archizePath, DATA_PATH);
+      } else {
+        log.info("Data (extracted) already exists at {}", extractedFile.getAbsolutePath());
+      }
+    }
+  }
+
+  public static void getMnistPNG() throws IOException {
+    String tmpDirStr = System.getProperty("java.io.tmpdir");
+    String archizePath = DATA_PATH + "/mnist_png.tar.gz";
+
+    if (tmpDirStr == null) {
+      throw new IOException("System property 'java.io.tmpdir' does specify a tmp dir");
     }
 
-    public static void getMnistPNG() throws IOException {
-        String tmpDirStr = System.getProperty("java.io.tmpdir");
-        String archizePath = DATA_PATH + "/mnist_png.tar.gz";
-
-        if (tmpDirStr == null) {
-            throw new IOException("System property 'java.io.tmpdir' does specify a tmp dir");
-        }
-        String url = "http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz";
-        File f = new File(archizePath);
-        File dir = new File(tmpDirStr);
-        if (!f.exists()) {
-            HttpClientBuilder builder = HttpClientBuilder.create();
-            CloseableHttpClient client = builder.build();
-            try (CloseableHttpResponse response = client.execute(new HttpGet(url))) {
-                HttpEntity entity = response.getEntity();
-                if (entity != null) {
-                    try (FileOutputStream outstream = new FileOutputStream(f)) {
-                        entity.writeTo(outstream);
-                        outstream.flush();
-                        outstream.close();
-                    }
-                }
-
-            }
-            System.out.println("Data downloaded to " + f.getAbsolutePath());
-        } else {
-            System.out.println("Using existing directory at " + f.getAbsolutePath());
-        }
-
+    File f = new File(archizePath);
+    if (!f.exists()) {
+      DataUtilities.downloadFile(DATA_URL, archizePath);
+      log.info("Data downloaded to ", f.getAbsolutePath());
+    } else {
+      log.info("Using existing directory at ", f.getAbsolutePath());
     }
+  }
 
-
-    }
-
-
+}

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExample.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExample.java
@@ -165,7 +165,7 @@ public class MnistImagePipelineExample {
     File f = new File(archizePath);
     if (!f.exists()) {
       DataUtilities.downloadFile(DATA_URL, archizePath);
-      log.info("Data downloaded to ", f.getAbsolutePath());
+      log.info("Data downloaded to ", archizePath);
     } else {
       log.info("Using existing directory at ", f.getAbsolutePath());
     }

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExampleAddNeuralNet.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExampleAddNeuralNet.java
@@ -1,14 +1,6 @@
 package org.deeplearning4j.examples.dataexamples;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.datavec.api.io.labels.ParentPathLabelGenerator;
 import org.datavec.api.split.FileSplit;
 import org.datavec.image.loader.NativeImageLoader;
@@ -39,285 +31,152 @@ import java.io.*;
 import java.util.Random;
 
 /**
- *  This code example is featured in this youtube video
- *  https://www.youtube.com/watch?v=ECA6y6ahH5E
+ * This code example is featured in this youtube video
+ * https://www.youtube.com/watch?v=ECA6y6ahH5E
  *
- ** This differs slightly from the Video Example,
+ * This differs slightly from the Video Example,
  * The Video example had the data already downloaded
  * This example includes code that downloads the data
  *
+ * Data is downloaded from
+ * wget http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
+ * followed by tar xzvf mnist_png.tar.gz
  *
- * The Data Directory mnist_png will have two child directories training and testing
- * The training and testing directories will have directories 0-9 with
- * 28 * 28 PNG images of handwritten images
- *
- *
- *
- *  The data is downloaded from
- *  wget http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
- *  followed by tar xzvf mnist_png.tar.gz
- *
- *
- *
- *  This examples builds on the MnistImagePipelineExample
- *  by adding a Neural Net
+ * This examples builds on the MnistImagePipelineExample
+ * by adding a Neural Net
  */
 public class MnistImagePipelineExampleAddNeuralNet {
-    private static Logger log = LoggerFactory.getLogger(MnistImagePipelineExampleAddNeuralNet.class);
+  private static Logger log = LoggerFactory.getLogger(MnistImagePipelineExampleAddNeuralNet.class);
 
-    /** Data URL for downloading */
-    public static final String DATA_URL = "http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz";
+  /** Data URL for downloading */
+  public static final String DATA_URL = "http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz";
 
-    /** Location to save and extract the training/testing data */
-    public static final String DATA_PATH = FilenameUtils.concat(System.getProperty("java.io.tmpdir"), "dl4j_Mnist/");
+  /** Location to save and extract the training/testing data */
+  public static final String DATA_PATH = FilenameUtils.concat(System.getProperty("java.io.tmpdir"), "dl4j_Mnist/");
 
+  public static void main(String[] args) throws Exception {
+    // image information
+    // 28 * 28 grayscale
+    // grayscale implies single channel
+    int height = 28;
+    int width = 28;
+    int channels = 1;
+    int rngseed = 123;
+    Random randNumGen = new Random(rngseed);
+    int batchSize = 128;
+    int outputNum = 10;
+    int numEpochs = 1;
 
-    public static void main(String[] args) throws Exception {
+    /*
+    This class downloadData() downloads the data
+    stores the data in java's tmpdir 15MB download compressed
+    It will take 158MB of space when uncompressed
+    The data can be downloaded manually here
+    http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
+    */
+    MnistImagePipelineExample.downloadData();
 
+    // Define the File Paths
+    File trainData = new File(DATA_PATH + "/mnist_png/training");
+    File testData = new File(DATA_PATH + "/mnist_png/testing");
 
+    // Define the FileSplit(PATH, ALLOWED FORMATS,random)
+    FileSplit train = new FileSplit(trainData, NativeImageLoader.ALLOWED_FORMATS, randNumGen);
+    FileSplit test = new FileSplit(testData, NativeImageLoader.ALLOWED_FORMATS, randNumGen);
 
-        // image information
-        // 28 * 28 grayscale
-        // grayscale implies single channel
-        int height = 28;
-        int width = 28;
-        int channels = 1;
-        int rngseed = 123;
-        Random randNumGen = new Random(rngseed);
-        int batchSize = 128;
-        int outputNum = 10;
-        int numEpochs = 1;
+    // Extract the parent path as the image label
+    ParentPathLabelGenerator labelMaker = new ParentPathLabelGenerator();
 
-         /*
-        This class downloadData() downloads the data
-        stores the data in java's tmpdir
-        15MB download compressed
-        It will take 158MB of space when uncompressed
-        The data can be downloaded manually here
-        http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
-         */
+    ImageRecordReader recordReader = new ImageRecordReader(height, width, channels, labelMaker);
 
+    // Initialize the record reader
+    // add a listener, to extract the name
+    recordReader.initialize(train);
+    //recordReader.setListeners(new LogRecordListener());
 
-        downloadData();
+    // DataSet Iterator
+    DataSetIterator dataIter = new RecordReaderDataSetIterator(recordReader, batchSize, 1, outputNum);
 
-        // Define the File Paths
-        File trainData = new File(DATA_PATH + "/mnist_png/training");
-        File testData = new File(DATA_PATH + "/mnist_png/testing");
+    // Scale pixel values to 0-1
+    DataNormalization scaler = new ImagePreProcessingScaler(0, 1);
+    scaler.fit(dataIter);
+    dataIter.setPreProcessor(scaler);
 
-        // Define the File Paths
-        //File trainData = new File("/tmp/mnist_png/training");
-        //File testData = new File("/tmp/mnist_png/testing");
+    // Build Our Neural Network
+    log.info("**** Build Model ****");
 
-        // Define the FileSplit(PATH, ALLOWED FORMATS,random)
+    MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+        .seed(rngseed)
+        .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+        .iterations(1)
+        .learningRate(0.006)
+        .updater(Updater.NESTEROVS)
+        .regularization(true).l2(1e-4)
+        .list()
+        .layer(0, new DenseLayer.Builder()
+            .nIn(height * width)
+            .nOut(100)
+            .activation(Activation.RELU)
+            .weightInit(WeightInit.XAVIER)
+            .build())
+        .layer(1, new OutputLayer.Builder(LossFunctions.LossFunction.NEGATIVELOGLIKELIHOOD)
+            .nIn(100)
+            .nOut(outputNum)
+            .activation(Activation.SOFTMAX)
+            .weightInit(WeightInit.XAVIER)
+            .build())
+        .pretrain(false).backprop(true)
+        .setInputType(InputType.convolutional(height, width, channels))
+        .build();
 
-        FileSplit train = new FileSplit(trainData, NativeImageLoader.ALLOWED_FORMATS,randNumGen);
-        FileSplit test = new FileSplit(testData,NativeImageLoader.ALLOWED_FORMATS,randNumGen);
+    MultiLayerNetwork model = new MultiLayerNetwork(conf);
 
-        // Extract the parent path as the image label
+    // The Score iteration Listener will log
+    // output to show how well the network is training
+    model.setListeners(new ScoreIterationListener(10));
 
-        ParentPathLabelGenerator labelMaker = new ParentPathLabelGenerator();
+    log.info("*****TRAIN MODEL********");
+    for (int i = 0; i < numEpochs; i++) {
+      model.fit(dataIter);
+    }
 
-        ImageRecordReader recordReader = new ImageRecordReader(height,width,channels,labelMaker);
+    log.info("******EVALUATE MODEL******");
 
-        // Initialize the record reader
-        // add a listener, to extract the name
+    recordReader.reset();
 
-        recordReader.initialize(train);
-        //recordReader.setListeners(new LogRecordListener());
+    // The model trained on the training dataset split
+    // now that it has trained we evaluate against the
+    // test data of images the network has not seen
 
-        // DataSet Iterator
+    recordReader.initialize(test);
+    DataSetIterator testIter = new RecordReaderDataSetIterator(recordReader, batchSize, 1, outputNum);
+    scaler.fit(testIter);
+    testIter.setPreProcessor(scaler);
 
-        DataSetIterator dataIter = new RecordReaderDataSetIterator(recordReader,batchSize,1,outputNum);
+    /*
+    log the order of the labels for later use
+    In previous versions the label order was consistent, but random
+    In current verions label order is lexicographic
+    preserving the RecordReader Labels order is no
+    longer needed left in for demonstration
+    purposes
+    */
+    log.info(recordReader.getLabels().toString());
 
-        // Scale pixel values to 0-1
+    // Create Eval object with 10 possible classes
+    Evaluation eval = new Evaluation(outputNum);
 
-        DataNormalization scaler = new ImagePreProcessingScaler(0,1);
-        scaler.fit(dataIter);
-        dataIter.setPreProcessor(scaler);
-
-
-        // Build Our Neural Network
-
-        log.info("**** Build Model ****");
-
-        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
-            .seed(rngseed)
-            .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
-            .iterations(1)
-            .learningRate(0.006)
-            .updater(Updater.NESTEROVS)
-            .regularization(true).l2(1e-4)
-            .list()
-            .layer(0, new DenseLayer.Builder()
-                .nIn(height * width)
-                .nOut(100)
-                .activation(Activation.RELU)
-                .weightInit(WeightInit.XAVIER)
-                .build())
-            .layer(1, new OutputLayer.Builder(LossFunctions.LossFunction.NEGATIVELOGLIKELIHOOD)
-                .nIn(100)
-                .nOut(outputNum)
-                .activation(Activation.SOFTMAX)
-                .weightInit(WeightInit.XAVIER)
-                .build())
-            .pretrain(false).backprop(true)
-            .setInputType(InputType.convolutional(height,width,channels))
-            .build();
-
-        MultiLayerNetwork model = new MultiLayerNetwork(conf);
-
-        // The Score iteration Listener will log
-        // output to show how well the network is training
-        model.setListeners(new ScoreIterationListener(10));
-
-        log.info("*****TRAIN MODEL********");
-        for(int i = 0; i<numEpochs; i++){
-            model.fit(dataIter);
-        }
-
-        log.info("******EVALUATE MODEL******");
-
-        recordReader.reset();
-
-        // The model trained on the training dataset split
-        // now that it has trained we evaluate against the
-        // test data of images the network has not seen
-
-        recordReader.initialize(test);
-        DataSetIterator testIter = new RecordReaderDataSetIterator(recordReader,batchSize,1,outputNum);
-        scaler.fit(testIter);
-        testIter.setPreProcessor(scaler);
-
-        /*
-        log the order of the labels for later use
-        In previous versions the label order was consistent, but random
-        In current verions label order is lexicographic
-        preserving the RecordReader Labels order is no
-        longer needed left in for demonstration
-        purposes
-        */
-        log.info(recordReader.getLabels().toString());
-
-        // Create Eval object with 10 possible classes
-        Evaluation eval = new Evaluation(outputNum);
-
-
-        // Evaluate the network
-        while(testIter.hasNext()){
-            DataSet next = testIter.next();
-            INDArray output = model.output(next.getFeatureMatrix());
-            // Compare the Feature Matrix from the model
-            // with the labels from the RecordReader
-            eval.eval(next.getLabels(),output);
-
-        }
-
-        log.info(eval.stats());
-
+    // Evaluate the network
+    while (testIter.hasNext()) {
+      DataSet next = testIter.next();
+      INDArray output = model.output(next.getFeatureMatrix());
+      // Compare the Feature Matrix from the model
+      // with the labels from the RecordReader
+      eval.eval(next.getLabels(), output);
 
     }
 
-     /*
-    Everything below here has nothing to do with your RecordReader,
-    or DataVec, or your Neural Network
-    The classes downloadData, getMnistPNG(),
-    and extractTarGz are for downloading and extracting the data
-     */
+    log.info(eval.stats());
+  }
 
-    private static void downloadData() throws Exception {
-        //Create directory if required
-        File directory = new File(DATA_PATH);
-        if(!directory.exists()) directory.mkdir();
-
-        //Download file:
-        String archizePath = DATA_PATH + "/mnist_png.tar.gz";
-        File archiveFile = new File(archizePath);
-        String extractedPath = DATA_PATH + "mnist_png";
-        File extractedFile = new File(extractedPath);
-
-        if( !archiveFile.exists() ){
-            System.out.println("Starting data download (15MB)...");
-            getMnistPNG();
-            //Extract tar.gz file to output directory
-            extractTarGz(archizePath, DATA_PATH);
-        } else {
-            //Assume if archive (.tar.gz) exists, then data has already been extracted
-            System.out.println("Data (.tar.gz file) already exists at " + archiveFile.getAbsolutePath());
-            if( !extractedFile.exists()){
-                //Extract tar.gz file to output directory
-                extractTarGz(archizePath, DATA_PATH);
-            } else {
-                System.out.println("Data (extracted) already exists at " + extractedFile.getAbsolutePath());
-            }
-        }
-
-
-    }
-
-    private static final int BUFFER_SIZE = 4096;
-    private static void extractTarGz(String filePath, String outputPath) throws IOException {
-        int fileCount = 0;
-        int dirCount = 0;
-        System.out.print("Extracting files");
-        try(TarArchiveInputStream tais = new TarArchiveInputStream(
-            new GzipCompressorInputStream( new BufferedInputStream( new FileInputStream(filePath))))){
-            TarArchiveEntry entry;
-
-            /** Read the tar entries using the getNextEntry method **/
-            while ((entry = (TarArchiveEntry) tais.getNextEntry()) != null) {
-                //System.out.println("Extracting file: " + entry.getName());
-
-                //Create directories as required
-                if (entry.isDirectory()) {
-                    new File(outputPath + entry.getName()).mkdirs();
-                    dirCount++;
-                }else {
-                    int count;
-                    byte data[] = new byte[BUFFER_SIZE];
-
-                    FileOutputStream fos = new FileOutputStream(outputPath + entry.getName());
-                    BufferedOutputStream dest = new BufferedOutputStream(fos,BUFFER_SIZE);
-                    while ((count = tais.read(data, 0, BUFFER_SIZE)) != -1) {
-                        dest.write(data, 0, count);
-                    }
-                    dest.close();
-                    fileCount++;
-                }
-                if(fileCount % 1000 == 0) System.out.print(".");
-            }
-        }
-
-        System.out.println("\n" + fileCount + " files and " + dirCount + " directories extracted to: " + outputPath);
-    }
-
-    public static void getMnistPNG() throws IOException {
-        String tmpDirStr = System.getProperty("java.io.tmpdir");
-        String archizePath = DATA_PATH + "/mnist_png.tar.gz";
-
-        if (tmpDirStr == null) {
-            throw new IOException("System property 'java.io.tmpdir' does specify a tmp dir");
-        }
-        String url = "http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz";
-        File f = new File(archizePath);
-        File dir = new File(tmpDirStr);
-        if (!f.exists()) {
-            HttpClientBuilder builder = HttpClientBuilder.create();
-            CloseableHttpClient client = builder.build();
-            try (CloseableHttpResponse response = client.execute(new HttpGet(url))) {
-                HttpEntity entity = response.getEntity();
-                if (entity != null) {
-                    try (FileOutputStream outstream = new FileOutputStream(f)) {
-                        entity.writeTo(outstream);
-                        outstream.flush();
-                        outstream.close();
-                    }
-                }
-
-            }
-            System.out.println("Data downloaded to " + f.getAbsolutePath());
-        } else {
-            System.out.println("Using existing directory at " + f.getAbsolutePath());
-        }
-
-    }
 }

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExampleAddNeuralNet.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExampleAddNeuralNet.java
@@ -103,8 +103,7 @@ public class MnistImagePipelineExampleAddNeuralNet {
     dataIter.setPreProcessor(scaler);
 
     // Build Our Neural Network
-    log.info("**** Build Model ****");
-
+    log.info("BUILD MODEL");
     MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
         .seed(rngseed)
         .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
@@ -135,13 +134,12 @@ public class MnistImagePipelineExampleAddNeuralNet {
     // output to show how well the network is training
     model.setListeners(new ScoreIterationListener(10));
 
-    log.info("*****TRAIN MODEL********");
+    log.info("TRAIN MODEL");
     for (int i = 0; i < numEpochs; i++) {
       model.fit(dataIter);
     }
 
-    log.info("******EVALUATE MODEL******");
-
+    log.info("EVALUATE MODEL");
     recordReader.reset();
 
     // The model trained on the training dataset split
@@ -173,7 +171,6 @@ public class MnistImagePipelineExampleAddNeuralNet {
       // Compare the Feature Matrix from the model
       // with the labels from the RecordReader
       eval.eval(next.getLabels(), output);
-
     }
 
     log.info(eval.stats());

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExampleLoad.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExampleLoad.java
@@ -1,14 +1,6 @@
 package org.deeplearning4j.examples.dataexamples;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.datavec.api.io.labels.ParentPathLabelGenerator;
 import org.datavec.api.split.FileSplit;
 import org.datavec.image.loader.NativeImageLoader;
@@ -29,35 +21,28 @@ import java.io.*;
 import java.util.Random;
 
 /**
- * /**
- *  This code example is featured in this youtube video
+ * This code example is featured in this youtube video
+ * https://www.youtube.com/watch?v=zrTSs715Ylo
  *
- *  https://www.youtube.com/watch?v=zrTSs715Ylo
- *
- * * This differs slightly from the Video Example,
+ * This differs slightly from the Video Example,
  * The Video example had the data already downloaded
  * This example includes code that downloads the data
  *
- *  Data is downloaded from
+ * Data is downloaded from
+ * wget http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
+ * followed by tar xzvf mnist_png.tar.gz
  *
- *
- *  wget http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
- *  followed by tar xzvf mnist_png.tar.gz
- *
- *
-
- *  This examples builds on the MnistImagePipelineExample
- *  by Loading the previously saved Neural Net
+ * This examples builds on the MnistImagePipelineExample
+ * by Loading the previously saved Neural Net
  */
 public class MnistImagePipelineExampleLoad {
+    private static Logger log = LoggerFactory.getLogger(MnistImagePipelineExampleLoad.class);
 
     /** Data URL for downloading */
     public static final String DATA_URL = "http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz";
 
     /** Location to save and extract the training/testing data */
     public static final String DATA_PATH = FilenameUtils.concat(System.getProperty("java.io.tmpdir"), "dl4j_Mnist/");
-
-    private static Logger log = LoggerFactory.getLogger(MnistImagePipelineExampleLoad.class);
 
     public static void main(String[] args) throws Exception {
         // image information
@@ -70,90 +55,64 @@ public class MnistImagePipelineExampleLoad {
         Random randNumGen = new Random(rngseed);
         int batchSize = 128;
         int outputNum = 10;
-        int numEpochs = 15;
 
-         /*
+        /*
         This class downloadData() downloads the data
-        stores the data in java's tmpdir
-        15MB download compressed
+        stores the data in java's tmpdir 15MB download compressed
         It will take 158MB of space when uncompressed
         The data can be downloaded manually here
         http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
-         */
-
-
-        downloadData();
+        */
+        MnistImagePipelineExample.downloadData();
 
         // Define the File Paths
         File trainData = new File(DATA_PATH + "/mnist_png/training");
         File testData = new File(DATA_PATH + "/mnist_png/testing");
 
-
         // Define the FileSplit(PATH, ALLOWED FORMATS,random)
-
         FileSplit train = new FileSplit(trainData, NativeImageLoader.ALLOWED_FORMATS,randNumGen);
         FileSplit test = new FileSplit(testData, NativeImageLoader.ALLOWED_FORMATS,randNumGen);
 
         // Extract the parent path as the image label
-
         ParentPathLabelGenerator labelMaker = new ParentPathLabelGenerator();
 
         ImageRecordReader recordReader = new ImageRecordReader(height,width,channels,labelMaker);
 
         // Initialize the record reader
         // add a listener, to extract the name
-
         recordReader.initialize(train);
         //recordReader.setListeners(new LogRecordListener());
 
         // DataSet Iterator
-
         DataSetIterator dataIter = new RecordReaderDataSetIterator(recordReader,batchSize,1,outputNum);
 
         // Scale pixel values to 0-1
-
         DataNormalization scaler = new ImagePreProcessingScaler(0,1);
         scaler.fit(dataIter);
         dataIter.setPreProcessor(scaler);
 
-
         // Build Our Neural Network
-
-
         log.info("******LOAD TRAINED MODEL******");
-        // Details
-
         // Where the saved model would be if
         // MnistImagePipelineSave has been run
         File locationToSave = new File("trained_mnist_model.zip");
 
-        if(locationToSave.exists()){
-            System.out.println("\n######Saved Model Found######\n");
-        }else{
-            System.out.println("\n\n#######File not found!#######");
-            System.out.println("This example depends on running ");
-            System.out.println("MnistImagePipelineExampleSave");
-            System.out.println("Run that Example First");
-            System.out.println("#############################\n\n");
-
-
+        if (locationToSave.exists()) {
+            log.info("\n######Saved Model Found######\n");
+        } else {
+            log.info("\n\n#######File not found!#######");
+            log.info("This example depends on running ");
+            log.info("MnistImagePipelineExampleSave");
+            log.info("Run that Example First");
+            log.info("#############################\n\n");
             System.exit(0);
         }
 
-
-
-
-
-
-
         MultiLayerNetwork model = ModelSerializer.restoreMultiLayerNetwork(locationToSave);
-
 
         model.getLabels();
 
-
-        //Test the Loaded Model with the test data
-
+        // Test the Loaded Model with the test data
         recordReader.initialize(test);
         DataSetIterator testIter = new RecordReaderDataSetIterator(recordReader,batchSize,1,outputNum);
         scaler.fit(testIter);
@@ -162,124 +121,13 @@ public class MnistImagePipelineExampleLoad {
         // Create Eval object with 10 possible classes
         Evaluation eval = new Evaluation(outputNum);
 
-
-
-
-        while(testIter.hasNext()){
+        while (testIter.hasNext()) {
             DataSet next = testIter.next();
             INDArray output = model.output(next.getFeatures());
             eval.eval(next.getLabels(),output);
-
         }
 
         log.info(eval.stats());
-
-
     }
-
-      /*
-    Everything below here has nothing to do with your RecordReader,
-    or DataVec, or your Neural Network
-    The classes downloadData, getMnistPNG(),
-    and extractTarGz are for downloading and extracting the data
-     */
-
-    private static void downloadData() throws Exception {
-        //Create directory if required
-        File directory = new File(DATA_PATH);
-        if(!directory.exists()) directory.mkdir();
-
-        //Download file:
-        String archizePath = DATA_PATH + "/mnist_png.tar.gz";
-        File archiveFile = new File(archizePath);
-        String extractedPath = DATA_PATH + "mnist_png";
-        File extractedFile = new File(extractedPath);
-
-        if( !archiveFile.exists() ){
-            System.out.println("Starting data download (15MB)...");
-            getMnistPNG();
-            //Extract tar.gz file to output directory
-            extractTarGz(archizePath, DATA_PATH);
-        } else {
-            //Assume if archive (.tar.gz) exists, then data has already been extracted
-            System.out.println("Data (.tar.gz file) already exists at " + archiveFile.getAbsolutePath());
-            if( !extractedFile.exists()){
-                //Extract tar.gz file to output directory
-                extractTarGz(archizePath, DATA_PATH);
-            } else {
-                System.out.println("Data (extracted) already exists at " + extractedFile.getAbsolutePath());
-            }
-        }
-
-
-    }
-
-    private static final int BUFFER_SIZE = 4096;
-    private static void extractTarGz(String filePath, String outputPath) throws IOException {
-        int fileCount = 0;
-        int dirCount = 0;
-        System.out.print("Extracting files");
-        try(TarArchiveInputStream tais = new TarArchiveInputStream(
-            new GzipCompressorInputStream( new BufferedInputStream( new FileInputStream(filePath))))){
-            TarArchiveEntry entry;
-
-            /** Read the tar entries using the getNextEntry method **/
-            while ((entry = (TarArchiveEntry) tais.getNextEntry()) != null) {
-                //System.out.println("Extracting file: " + entry.getName());
-
-                //Create directories as required
-                if (entry.isDirectory()) {
-                    new File(outputPath + entry.getName()).mkdirs();
-                    dirCount++;
-                }else {
-                    int count;
-                    byte data[] = new byte[BUFFER_SIZE];
-
-                    FileOutputStream fos = new FileOutputStream(outputPath + entry.getName());
-                    BufferedOutputStream dest = new BufferedOutputStream(fos,BUFFER_SIZE);
-                    while ((count = tais.read(data, 0, BUFFER_SIZE)) != -1) {
-                        dest.write(data, 0, count);
-                    }
-                    dest.close();
-                    fileCount++;
-                }
-                if(fileCount % 1000 == 0) System.out.print(".");
-            }
-        }
-
-        System.out.println("\n" + fileCount + " files and " + dirCount + " directories extracted to: " + outputPath);
-    }
-
-    public static void getMnistPNG() throws IOException {
-        String tmpDirStr = System.getProperty("java.io.tmpdir");
-        String archizePath = DATA_PATH + "/mnist_png.tar.gz";
-
-        if (tmpDirStr == null) {
-            throw new IOException("System property 'java.io.tmpdir' does specify a tmp dir");
-        }
-        String url = "http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz";
-        File f = new File(archizePath);
-        File dir = new File(tmpDirStr);
-        if (!f.exists()) {
-            HttpClientBuilder builder = HttpClientBuilder.create();
-            CloseableHttpClient client = builder.build();
-            try (CloseableHttpResponse response = client.execute(new HttpGet(url))) {
-                HttpEntity entity = response.getEntity();
-                if (entity != null) {
-                    try (FileOutputStream outstream = new FileOutputStream(f)) {
-                        entity.writeTo(outstream);
-                        outstream.flush();
-                        outstream.close();
-                    }
-                }
-
-            }
-            System.out.println("Data downloaded to " + f.getAbsolutePath());
-        } else {
-            System.out.println("Using existing directory at " + f.getAbsolutePath());
-        }
-
-    }
-
 
 }

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExampleLoad.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExampleLoad.java
@@ -36,98 +36,95 @@ import java.util.Random;
  * by Loading the previously saved Neural Net
  */
 public class MnistImagePipelineExampleLoad {
-    private static Logger log = LoggerFactory.getLogger(MnistImagePipelineExampleLoad.class);
+  private static Logger log = LoggerFactory.getLogger(MnistImagePipelineExampleLoad.class);
 
-    /** Data URL for downloading */
-    public static final String DATA_URL = "http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz";
+  /** Data URL for downloading */
+  public static final String DATA_URL = "http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz";
 
-    /** Location to save and extract the training/testing data */
-    public static final String DATA_PATH = FilenameUtils.concat(System.getProperty("java.io.tmpdir"), "dl4j_Mnist/");
+  /** Location to save and extract the training/testing data */
+  public static final String DATA_PATH = FilenameUtils.concat(System.getProperty("java.io.tmpdir"), "dl4j_Mnist/");
 
-    public static void main(String[] args) throws Exception {
-        // image information
-        // 28 * 28 grayscale
-        // grayscale implies single channel
-        int height = 28;
-        int width = 28;
-        int channels = 1;
-        int rngseed = 123;
-        Random randNumGen = new Random(rngseed);
-        int batchSize = 128;
-        int outputNum = 10;
+  public static void main(String[] args) throws Exception {
+    // image information
+    // 28 * 28 grayscale
+    // grayscale implies single channel
+    int height = 28;
+    int width = 28;
+    int channels = 1;
+    int rngseed = 123;
+    Random randNumGen = new Random(rngseed);
+    int batchSize = 128;
+    int outputNum = 10;
 
-        /*
-        This class downloadData() downloads the data
-        stores the data in java's tmpdir 15MB download compressed
-        It will take 158MB of space when uncompressed
-        The data can be downloaded manually here
-        http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
-        */
-        MnistImagePipelineExample.downloadData();
+    /*
+    This class downloadData() downloads the data
+    stores the data in java's tmpdir 15MB download compressed
+    It will take 158MB of space when uncompressed
+    The data can be downloaded manually here
+    http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
+    */
+    MnistImagePipelineExample.downloadData();
 
-        // Define the File Paths
-        File trainData = new File(DATA_PATH + "/mnist_png/training");
-        File testData = new File(DATA_PATH + "/mnist_png/testing");
+    // Define the File Paths
+    File trainData = new File(DATA_PATH + "/mnist_png/training");
+    File testData = new File(DATA_PATH + "/mnist_png/testing");
 
-        // Define the FileSplit(PATH, ALLOWED FORMATS,random)
-        FileSplit train = new FileSplit(trainData, NativeImageLoader.ALLOWED_FORMATS,randNumGen);
-        FileSplit test = new FileSplit(testData, NativeImageLoader.ALLOWED_FORMATS,randNumGen);
+    // Define the FileSplit(PATH, ALLOWED FORMATS,random)
+    FileSplit train = new FileSplit(trainData, NativeImageLoader.ALLOWED_FORMATS, randNumGen);
+    FileSplit test = new FileSplit(testData, NativeImageLoader.ALLOWED_FORMATS, randNumGen);
 
-        // Extract the parent path as the image label
-        ParentPathLabelGenerator labelMaker = new ParentPathLabelGenerator();
+    // Extract the parent path as the image label
+    ParentPathLabelGenerator labelMaker = new ParentPathLabelGenerator();
 
-        ImageRecordReader recordReader = new ImageRecordReader(height,width,channels,labelMaker);
+    ImageRecordReader recordReader = new ImageRecordReader(height, width, channels, labelMaker);
 
-        // Initialize the record reader
-        // add a listener, to extract the name
-        recordReader.initialize(train);
-        //recordReader.setListeners(new LogRecordListener());
+    // Initialize the record reader
+    // add a listener, to extract the name
+    recordReader.initialize(train);
+    //recordReader.setListeners(new LogRecordListener());
 
-        // DataSet Iterator
-        DataSetIterator dataIter = new RecordReaderDataSetIterator(recordReader,batchSize,1,outputNum);
+    // DataSet Iterator
+    DataSetIterator dataIter = new RecordReaderDataSetIterator(recordReader, batchSize, 1, outputNum);
 
-        // Scale pixel values to 0-1
-        DataNormalization scaler = new ImagePreProcessingScaler(0,1);
-        scaler.fit(dataIter);
-        dataIter.setPreProcessor(scaler);
+    // Scale pixel values to 0-1
+    DataNormalization scaler = new ImagePreProcessingScaler(0, 1);
+    scaler.fit(dataIter);
+    dataIter.setPreProcessor(scaler);
 
-        // Build Our Neural Network
-        log.info("******LOAD TRAINED MODEL******");
-        // Where the saved model would be if
-        // MnistImagePipelineSave has been run
-        File locationToSave = new File("trained_mnist_model.zip");
+    // Build Our Neural Network
+    log.info("LOAD TRAINED MODEL");
+    // Where the saved model would be if
+    // MnistImagePipelineSave has been run
+    File locationToSave = new File(DATA_PATH + "trained_mnist_model.zip");
 
-        if (locationToSave.exists()) {
-            log.info("\n######Saved Model Found######\n");
-        } else {
-            log.info("\n\n#######File not found!#######");
-            log.info("This example depends on running ");
-            log.info("MnistImagePipelineExampleSave");
-            log.info("Run that Example First");
-            log.info("#############################\n\n");
-            System.exit(0);
-        }
-
-        MultiLayerNetwork model = ModelSerializer.restoreMultiLayerNetwork(locationToSave);
-
-        model.getLabels();
-
-        // Test the Loaded Model with the test data
-        recordReader.initialize(test);
-        DataSetIterator testIter = new RecordReaderDataSetIterator(recordReader,batchSize,1,outputNum);
-        scaler.fit(testIter);
-        testIter.setPreProcessor(scaler);
-
-        // Create Eval object with 10 possible classes
-        Evaluation eval = new Evaluation(outputNum);
-
-        while (testIter.hasNext()) {
-            DataSet next = testIter.next();
-            INDArray output = model.output(next.getFeatures());
-            eval.eval(next.getLabels(),output);
-        }
-
-        log.info(eval.stats());
+    if (locationToSave.exists()) {
+      log.info("Saved Model Found!");
+    } else {
+      log.error("File not found!");
+      log.error("This example depends on running MnistImagePipelineExampleSave, run that example first");
+      System.exit(0);
     }
+
+    MultiLayerNetwork model = ModelSerializer.restoreMultiLayerNetwork(locationToSave);
+
+    model.getLabels();
+
+    // Test the Loaded Model with the test data
+    recordReader.initialize(test);
+    DataSetIterator testIter = new RecordReaderDataSetIterator(recordReader, batchSize, 1, outputNum);
+    scaler.fit(testIter);
+    testIter.setPreProcessor(scaler);
+
+    // Create Eval object with 10 possible classes
+    Evaluation eval = new Evaluation(outputNum);
+
+    while (testIter.hasNext()) {
+      DataSet next = testIter.next();
+      INDArray output = model.output(next.getFeatures());
+      eval.eval(next.getLabels(), output);
+    }
+
+    log.info(eval.stats());
+  }
 
 }

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExampleSave.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExampleSave.java
@@ -1,14 +1,6 @@
 package org.deeplearning4j.examples.dataexamples;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.datavec.api.io.labels.ParentPathLabelGenerator;
 import org.datavec.api.split.FileSplit;
 import org.datavec.image.loader.NativeImageLoader;
@@ -37,253 +29,121 @@ import java.io.*;
 import java.util.Random;
 
 /**
- * /**
- *  This code example is featured in this youtube video
+ * This code example is featured in this youtube video
+ * https://www.youtube.com/watch?v=zrTSs715Ylo
  *
- *  https://www.youtube.com/watch?v=zrTSs715Ylo
- *
- ** This differs slightly from the Video Example,
+ * This differs slightly from the Video Example,
  * The Video example had the data already downloaded
  * This example includes code that downloads the data
  *
- * Data SOurce
- *  wget http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
- *  followed by tar xzvf mnist_png.tar.gz
- *
- *  OR
- *  git clone https://github.com/myleott/mnist_png.git
- *  cd mnist_png
- *  tar xvf mnist_png.tar.gz
- *
- *
- *
- *  This examples builds on the MnistImagePipelineExample
- *  by Saving the Trained Network
- *
+ * Data is downloaded from
+ * wget http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
+ * followed by tar xzvf mnist_png.tar.gz
+ * 
+ * This examples builds on the MnistImagePipelineExample
+ * by Saving the Trained Network
  */
 public class MnistImagePipelineExampleSave {
-    /** Data URL for downloading */
-    public static final String DATA_URL = "http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz";
+  private static Logger log = LoggerFactory.getLogger(MnistImagePipelineExampleSave.class);
 
-    /** Location to save and extract the training/testing data */
-    public static final String DATA_PATH = FilenameUtils.concat(System.getProperty("java.io.tmpdir"), "dl4j_Mnist/");
+  /** Data URL for downloading */
+  public static final String DATA_URL = "http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz";
 
-    private static Logger log = LoggerFactory.getLogger(MnistImagePipelineExampleSave.class);
+  /** Location to save and extract the training/testing data */
+  public static final String DATA_PATH = FilenameUtils.concat(System.getProperty("java.io.tmpdir"), "dl4j_Mnist/");
 
-    public static void main(String[] args) throws Exception {
-        // image information
-        // 28 * 28 grayscale
-        // grayscale implies single channel
-        int height = 28;
-        int width = 28;
-        int channels = 1;
-        int rngseed = 123;
-        Random randNumGen = new Random(rngseed);
-        int batchSize = 128;
-        int outputNum = 10;
-        int numEpochs = 15;
+  public static void main(String[] args) throws Exception {
+    // image information
+    // 28 * 28 grayscale
+    // grayscale implies single channel
+    int height = 28;
+    int width = 28;
+    int channels = 1;
+    int rngseed = 123;
+    Random randNumGen = new Random(rngseed);
+    int batchSize = 128;
+    int outputNum = 10;
+    int numEpochs = 15;
 
-         /*
-        This class downloadData() downloads the data
-        stores the data in java's tmpdir
-        15MB download compressed
-        It will take 158MB of space when uncompressed
-        The data can be downloaded manually here
-        http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
-         */
+    /*
+    This class downloadData() downloads the data
+    stores the data in java's tmpdir 15MB download compressed
+    It will take 158MB of space when uncompressed
+    The data can be downloaded manually here
+    http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
+    */
+    MnistImagePipelineExample.downloadData();
 
+    // Define the File Paths
+    File trainData = new File(DATA_PATH + "/mnist_png/training");
 
-        downloadData();
+    // Define the FileSplit(PATH, ALLOWED FORMATS,random)
+    FileSplit train = new FileSplit(trainData, NativeImageLoader.ALLOWED_FORMATS, randNumGen);
 
-        // Define the File Paths
-        File trainData = new File(DATA_PATH + "/mnist_png/training");
-        File testData = new File(DATA_PATH + "/mnist_png/testing");
+    // Extract the parent path as the image label
+    ParentPathLabelGenerator labelMaker = new ParentPathLabelGenerator();
 
+    ImageRecordReader recordReader = new ImageRecordReader(height, width, channels, labelMaker);
 
-        // Define the FileSplit(PATH, ALLOWED FORMATS,random)
+    // Initialize the record reader
+    // add a listener, to extract the name
+    recordReader.initialize(train);
+    //recordReader.setListeners(new LogRecordListener());
 
-        FileSplit train = new FileSplit(trainData, NativeImageLoader.ALLOWED_FORMATS,randNumGen);
-        FileSplit test = new FileSplit(testData,NativeImageLoader.ALLOWED_FORMATS,randNumGen);
+    // DataSet Iterator
+    DataSetIterator dataIter = new RecordReaderDataSetIterator(recordReader, batchSize, 1, outputNum);
 
-        // Extract the parent path as the image label
+    // Scale pixel values to 0-1
+    DataNormalization scaler = new ImagePreProcessingScaler(0, 1);
+    scaler.fit(dataIter);
+    dataIter.setPreProcessor(scaler);
 
-        ParentPathLabelGenerator labelMaker = new ParentPathLabelGenerator();
+    // Build Our Neural Network
+    log.info("**** Build Model ****");
 
-        ImageRecordReader recordReader = new ImageRecordReader(height,width,channels,labelMaker);
+    MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
+        .seed(rngseed)
+        .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+        .iterations(1)
+        .learningRate(0.006)
+        .updater(new Nesterovs(0.9))
+        .regularization(true).l2(1e-4)
+        .list()
+        .layer(0, new DenseLayer.Builder()
+            .nIn(height * width)
+            .nOut(100)
+            .activation(Activation.RELU)
+            .weightInit(WeightInit.XAVIER)
+            .build())
+        .layer(1, new OutputLayer.Builder(LossFunctions.LossFunction.NEGATIVELOGLIKELIHOOD)
+            .nIn(100)
+            .nOut(outputNum)
+            .activation(Activation.SOFTMAX)
+            .weightInit(WeightInit.XAVIER)
+            .build())
+        .pretrain(false).backprop(true)
+        .setInputType(InputType.convolutional(height, width, channels))
+        .build();
 
-        // Initialize the record reader
-        // add a listener, to extract the name
+    MultiLayerNetwork model = new MultiLayerNetwork(conf);
+    model.init();
 
-        recordReader.initialize(train);
-        //recordReader.setListeners(new LogRecordListener());
+    model.setListeners(new ScoreIterationListener(10));
 
-        // DataSet Iterator
-
-        DataSetIterator dataIter = new RecordReaderDataSetIterator(recordReader,batchSize,1,outputNum);
-
-        // Scale pixel values to 0-1
-
-        DataNormalization scaler = new ImagePreProcessingScaler(0,1);
-        scaler.fit(dataIter);
-        dataIter.setPreProcessor(scaler);
-
-
-        // Build Our Neural Network
-
-        log.info("**** Build Model ****");
-
-        MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
-            .seed(rngseed)
-            .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
-            .iterations(1)
-            .learningRate(0.006)
-            .updater(new Nesterovs(0.9))
-            .regularization(true).l2(1e-4)
-            .list()
-            .layer(0, new DenseLayer.Builder()
-                .nIn(height * width)
-                .nOut(100)
-                .activation(Activation.RELU)
-                .weightInit(WeightInit.XAVIER)
-                .build())
-            .layer(1, new OutputLayer.Builder(LossFunctions.LossFunction.NEGATIVELOGLIKELIHOOD)
-                .nIn(100)
-                .nOut(outputNum)
-                .activation(Activation.SOFTMAX)
-                .weightInit(WeightInit.XAVIER)
-                .build())
-            .pretrain(false).backprop(true)
-            .setInputType(InputType.convolutional(height,width,channels))
-            .build();
-
-        MultiLayerNetwork model = new MultiLayerNetwork(conf);
-        model.init();
-
-        model.setListeners(new ScoreIterationListener(10));
-
-        log.info("*****TRAIN MODEL********");
-        for(int i = 0; i<numEpochs; i++){
-            model.fit(dataIter);
-        }
-
-        log.info("******SAVE TRAINED MODEL******");
-        // Details
-
-        // Where to save model
-        File locationToSave = new File("trained_mnist_model.zip");
-
-        // boolean save Updater
-        boolean saveUpdater = false;
-
-        // ModelSerializer needs modelname, saveUpdater, Location
-
-        ModelSerializer.writeModel(model,locationToSave,saveUpdater);
-
-
-    }
-      /*
-    Everything below here has nothing to do with your RecordReader,
-    or DataVec, or your Neural Network
-    The classes downloadData, getMnistPNG(),
-    and extractTarGz are for downloading and extracting the data
-     */
-
-    private static void downloadData() throws Exception {
-        //Create directory if required
-        File directory = new File(DATA_PATH);
-        if(!directory.exists()) directory.mkdir();
-
-        //Download file:
-        String archizePath = DATA_PATH + "/mnist_png.tar.gz";
-        File archiveFile = new File(archizePath);
-        String extractedPath = DATA_PATH + "mnist_png";
-        File extractedFile = new File(extractedPath);
-
-        if( !archiveFile.exists() ){
-            System.out.println("Starting data download (15MB)...");
-            getMnistPNG();
-            //Extract tar.gz file to output directory
-            extractTarGz(archizePath, DATA_PATH);
-        } else {
-            //Assume if archive (.tar.gz) exists, then data has already been extracted
-            System.out.println("Data (.tar.gz file) already exists at " + archiveFile.getAbsolutePath());
-            if( !extractedFile.exists()){
-                //Extract tar.gz file to output directory
-                extractTarGz(archizePath, DATA_PATH);
-            } else {
-                System.out.println("Data (extracted) already exists at " + extractedFile.getAbsolutePath());
-            }
-        }
-
-
+    log.info("*****TRAIN MODEL********");
+    for (int i = 0; i < numEpochs; i++) {
+      model.fit(dataIter);
     }
 
-    private static final int BUFFER_SIZE = 4096;
-    private static void extractTarGz(String filePath, String outputPath) throws IOException {
-        int fileCount = 0;
-        int dirCount = 0;
-        System.out.print("Extracting files");
-        try(TarArchiveInputStream tais = new TarArchiveInputStream(
-            new GzipCompressorInputStream( new BufferedInputStream( new FileInputStream(filePath))))){
-            TarArchiveEntry entry;
+    log.info("******SAVE TRAINED MODEL******");
+    // Where to save model
+    File locationToSave = new File("trained_mnist_model.zip");
 
-            /** Read the tar entries using the getNextEntry method **/
-            while ((entry = (TarArchiveEntry) tais.getNextEntry()) != null) {
-                //System.out.println("Extracting file: " + entry.getName());
+    // boolean save Updater
+    boolean saveUpdater = false;
 
-                //Create directories as required
-                if (entry.isDirectory()) {
-                    new File(outputPath + entry.getName()).mkdirs();
-                    dirCount++;
-                }else {
-                    int count;
-                    byte data[] = new byte[BUFFER_SIZE];
-
-                    FileOutputStream fos = new FileOutputStream(outputPath + entry.getName());
-                    BufferedOutputStream dest = new BufferedOutputStream(fos,BUFFER_SIZE);
-                    while ((count = tais.read(data, 0, BUFFER_SIZE)) != -1) {
-                        dest.write(data, 0, count);
-                    }
-                    dest.close();
-                    fileCount++;
-                }
-                if(fileCount % 1000 == 0) System.out.print(".");
-            }
-        }
-
-        System.out.println("\n" + fileCount + " files and " + dirCount + " directories extracted to: " + outputPath);
-    }
-
-    public static void getMnistPNG() throws IOException {
-        String tmpDirStr = System.getProperty("java.io.tmpdir");
-        String archizePath = DATA_PATH + "/mnist_png.tar.gz";
-
-        if (tmpDirStr == null) {
-            throw new IOException("System property 'java.io.tmpdir' does specify a tmp dir");
-        }
-        String url = "http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz";
-        File f = new File(archizePath);
-        File dir = new File(tmpDirStr);
-        if (!f.exists()) {
-            HttpClientBuilder builder = HttpClientBuilder.create();
-            CloseableHttpClient client = builder.build();
-            try (CloseableHttpResponse response = client.execute(new HttpGet(url))) {
-                HttpEntity entity = response.getEntity();
-                if (entity != null) {
-                    try (FileOutputStream outstream = new FileOutputStream(f)) {
-                        entity.writeTo(outstream);
-                        outstream.flush();
-                        outstream.close();
-                    }
-                }
-
-            }
-            System.out.println("Data downloaded to " + f.getAbsolutePath());
-        } else {
-            System.out.println("Using existing directory at " + f.getAbsolutePath());
-        }
-
-    }
-
+    // ModelSerializer needs modelname, saveUpdater, Location
+    ModelSerializer.writeModel(model, locationToSave, saveUpdater);
+  }
 
 }

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExampleSave.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineExampleSave.java
@@ -99,8 +99,7 @@ public class MnistImagePipelineExampleSave {
     dataIter.setPreProcessor(scaler);
 
     // Build Our Neural Network
-    log.info("**** Build Model ****");
-
+    log.info("BUILD MODEL");
     MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
         .seed(rngseed)
         .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
@@ -130,14 +129,14 @@ public class MnistImagePipelineExampleSave {
 
     model.setListeners(new ScoreIterationListener(10));
 
-    log.info("*****TRAIN MODEL********");
+    log.info("TRAIN MODEL");
     for (int i = 0; i < numEpochs; i++) {
       model.fit(dataIter);
     }
 
-    log.info("******SAVE TRAINED MODEL******");
+    log.info("SAVE TRAINED MODEL");
     // Where to save model
-    File locationToSave = new File("trained_mnist_model.zip");
+    File locationToSave = new File(DATA_PATH + "trained_mnist_model.zip");
 
     // boolean save Updater
     boolean saveUpdater = false;

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineLoadChooser.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineLoadChooser.java
@@ -15,126 +15,104 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * /**
- *  This code example is featured in this youtube video
- *
- *  http://www.youtube.com/watch?v=DRHIpeJpJDI
+ * This code example is featured in this youtube video
+ * http://www.youtube.com/watch?v=DRHIpeJpJDI
  *
  * This differs slightly from the Video Example,
  * The Video example had the data already downloaded
  * This example includes code that downloads the data
  *
- *  Data is downloaded from
+ * Data is downloaded from
+ * wget http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
+ * followed by tar xzvf mnist_png.tar.gz
  *
- *
- *  wget http://github.com/myleott/mnist_png/raw/master/mnist_png.tar.gz
- *  followed by tar xzvf mnist_png.tar.gz
- * The Data Directory mnist_png will have two child directories training and testing
- * The training and testing directories will have directories 0-9 with
- * 28 * 28 PNG images of handwritten images
- *
- *
- *
- *
- *
- *  This examples builds on the MnistImagePipelineExample
- *  by giving the user a file chooser to test an image of their choice
- *  against the Nueral Net, will the network think this cat is an 8 or a 1
- *  Seriously you can test anything, but obviously the network was trained on handwritten images
- *  0-9 white digit, black background, so it will work better with stuff closer to what it was
- *  designed for
- *
+ * This examples builds on the MnistImagePipelineExample
+ * by giving the user a file chooser to test an image of their choice
+ * against the Nueral Net, will the network think this cat is an 8 or a 1
+ * 
+ * Seriously you can test anything, but obviously the network was trained 
+ * on handwritten images 0-9 white digit, black background, so it will work 
+ * better with stuff closer to what it was designed for
  */
 public class MnistImagePipelineLoadChooser {
-    private static Logger log = LoggerFactory.getLogger(MnistImagePipelineLoadChooser.class);
+  private static Logger log = LoggerFactory.getLogger(MnistImagePipelineLoadChooser.class);
 
+  /*
+  Create a popup window to allow you to chose an image file to test against the
+  trained Neural Network
+  Chosen images will be automatically
+  scaled to 28*28 grayscale
+   */
+  public static String fileChose() {
+    JFileChooser fc = new JFileChooser();
+    int ret = fc.showOpenDialog(null);
+    if (ret == JFileChooser.APPROVE_OPTION) {
+      File file = fc.getSelectedFile();
+      String filename = file.getAbsolutePath();
+      return filename;
+    } else {
+      return null;
+    }
+  }
 
-    /*
-    Create a popup window to allow you to chose an image file to test against the
-    trained Neural Network
-    Chosen images will be automatically
-    scaled to 28*28 grayscale
-     */
-    public static String fileChose(){
-        JFileChooser fc = new JFileChooser();
-        int ret = fc.showOpenDialog(null);
-        if (ret == JFileChooser.APPROVE_OPTION)
-        {
-            File file = fc.getSelectedFile();
-            String filename = file.getAbsolutePath();
-            return filename;
-        }
-        else {
-            return null;
-        }
+  public static void main(String[] args) throws Exception {
+    int height = 28;
+    int width = 28;
+    int channels = 1;
+
+    // recordReader.getLabels()
+    // In this version Labels are always in order
+    // So this is no longer needed
+    //List<Integer> labelList = Arrays.asList(2,3,7,1,6,4,0,5,8,9);
+    List<Integer> labelList = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+    // pop up file chooser
+    String filechose = fileChose().toString();
+
+    //LOAD NEURAL NETWORK
+
+    // Where to save model
+    File locationToSave = new File("trained_mnist_model.zip");
+    // Check for presence of saved model
+    if (locationToSave.exists()) {
+      System.out.println("\n######Saved Model Found######\n");
+    } else {
+      System.out.println("\n\n#######File not found!#######");
+      System.out.println("This example depends on running ");
+      System.out.println("MnistImagePipelineExampleSave");
+      System.out.println("Run that Example First");
+      System.out.println("#############################\n\n");
+      System.exit(0);
     }
 
-    public static void main(String[] args) throws Exception{
-        int height = 28;
-        int width = 28;
-        int channels = 1;
+    MultiLayerNetwork model = ModelSerializer.restoreMultiLayerNetwork(locationToSave);
 
-        // recordReader.getLabels()
-        // In this version Labels are always in order
-        // So this is no longer needed
-        //List<Integer> labelList = Arrays.asList(2,3,7,1,6,4,0,5,8,9);
-        List<Integer> labelList = Arrays.asList(0,1,2,3,4,5,6,7,8,9);
+    log.info("*********TEST YOUR IMAGE AGAINST SAVED NETWORK********");
 
-        // pop up file chooser
-        String filechose = fileChose().toString();
+    // FileChose is a string we will need a file
+    File file = new File(filechose);
 
-        //LOAD NEURAL NETWORK
+    // Use NativeImageLoader to convert to numerical matrix
+    NativeImageLoader loader = new NativeImageLoader(height, width, channels);
 
-        // Where to save model
-        File locationToSave = new File("trained_mnist_model.zip");
-        // Check for presence of saved model
-        if(locationToSave.exists()){
-            System.out.println("\n######Saved Model Found######\n");
-        }else{
-            System.out.println("\n\n#######File not found!#######");
-            System.out.println("This example depends on running ");
-            System.out.println("MnistImagePipelineExampleSave");
-            System.out.println("Run that Example First");
-            System.out.println("#############################\n\n");
+    // Get the image into an INDarray
+    INDArray image = loader.asMatrix(file);
 
+    // 0-255
+    // 0-1
+    DataNormalization scaler = new ImagePreProcessingScaler(0, 1);
+    scaler.transform(image);
+    // Pass through to neural Net
 
-            System.exit(0);
-        }
+    INDArray output = model.output(image);
 
-        MultiLayerNetwork model = ModelSerializer.restoreMultiLayerNetwork(locationToSave);
-
-        log.info("*********TEST YOUR IMAGE AGAINST SAVED NETWORK********");
-
-        // FileChose is a string we will need a file
-
-        File file = new File(filechose);
-
-        // Use NativeImageLoader to convert to numerical matrix
-
-        NativeImageLoader loader = new NativeImageLoader(height, width, channels);
-
-        // Get the image into an INDarray
-
-        INDArray image = loader.asMatrix(file);
-
-        // 0-255
-        // 0-1
-        DataNormalization scaler = new ImagePreProcessingScaler(0,1);
-        scaler.transform(image);
-        // Pass through to neural Net
-
-        INDArray output = model.output(image);
-
-        log.info("## The FILE CHOSEN WAS " + filechose);
-        log.info("## The Neural Nets Pediction ##");
-        log.info("## list of probabilities per label ##");
-        //log.info("## List of Labels in Order## ");
-        // In new versions labels are always in order
-        log.info(output.toString());
-        log.info(labelList.toString());
-
-    }
-
-
+    log.info("## The FILE CHOSEN WAS " + filechose);
+    log.info("## The Neural Nets Pediction ##");
+    log.info("## list of probabilities per label ##");
+    //log.info("## List of Labels in Order## ");
+    // In new versions labels are always in order
+    log.info(output.toString());
+    log.info(labelList.toString());
+  }
 
 }

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineLoadChooser.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/dataexamples/MnistImagePipelineLoadChooser.java
@@ -1,5 +1,6 @@
 package org.deeplearning4j.examples.dataexamples;
 
+import org.apache.commons.io.FilenameUtils;
 import org.datavec.image.loader.NativeImageLoader;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.util.ModelSerializer;
@@ -36,13 +37,16 @@ import java.util.List;
  */
 public class MnistImagePipelineLoadChooser {
   private static Logger log = LoggerFactory.getLogger(MnistImagePipelineLoadChooser.class);
+  
+  /** Location to save and extract the training/testing data */
+  public static final String DATA_PATH = FilenameUtils.concat(System.getProperty("java.io.tmpdir"), "dl4j_Mnist/");
 
   /*
   Create a popup window to allow you to chose an image file to test against the
   trained Neural Network
   Chosen images will be automatically
   scaled to 28*28 grayscale
-   */
+  */
   public static String fileChose() {
     JFileChooser fc = new JFileChooser();
     int ret = fc.showOpenDialog(null);
@@ -72,23 +76,19 @@ public class MnistImagePipelineLoadChooser {
     //LOAD NEURAL NETWORK
 
     // Where to save model
-    File locationToSave = new File("trained_mnist_model.zip");
+    File locationToSave = new File(DATA_PATH + "trained_mnist_model.zip");
     // Check for presence of saved model
     if (locationToSave.exists()) {
-      System.out.println("\n######Saved Model Found######\n");
+      log.info("Saved Model Found!");
     } else {
-      System.out.println("\n\n#######File not found!#######");
-      System.out.println("This example depends on running ");
-      System.out.println("MnistImagePipelineExampleSave");
-      System.out.println("Run that Example First");
-      System.out.println("#############################\n\n");
+      log.error("File not found!");
+      log.error("This example depends on running MnistImagePipelineExampleSave, run that example first");
       System.exit(0);
     }
 
     MultiLayerNetwork model = ModelSerializer.restoreMultiLayerNetwork(locationToSave);
 
-    log.info("*********TEST YOUR IMAGE AGAINST SAVED NETWORK********");
-
+    log.info("TEST YOUR IMAGE AGAINST SAVED NETWORK");
     // FileChose is a string we will need a file
     File file = new File(filechose);
 
@@ -102,13 +102,12 @@ public class MnistImagePipelineLoadChooser {
     // 0-1
     DataNormalization scaler = new ImagePreProcessingScaler(0, 1);
     scaler.transform(image);
+    
     // Pass through to neural Net
-
     INDArray output = model.output(image);
 
-    log.info("## The FILE CHOSEN WAS " + filechose);
-    log.info("## The Neural Nets Pediction ##");
-    log.info("## list of probabilities per label ##");
+    log.info("The file chosen was " + filechose);
+    log.info("The neural nets prediction (list of probabilities per label)");
     //log.info("## List of Labels in Order## ");
     // In new versions labels are always in order
     log.info(output.toString());


### PR DESCRIPTION
## What changes were proposed in this pull request?

I'm basically merging `MnistImagePipelineExample` and `LenetMnistExample` with some hyperparameters tuning to achieve 99% accuracy. 
I have also done some cleanup to the existing code.

I would like to thank @jesuino for his nice JavaFX test console.

```
o.n.l.f.Nd4jBackend - Loaded [CpuBackend] backend
o.n.n.NativeOpsHolder - Number of threads used for NativeOps: 2
o.n.n.Nd4jBlas - Number of threads used for BLAS: 2
o.n.l.a.o.e.DefaultOpExecutioner - Backend used: [CPU]; OS: [Windows 7]
o.n.l.a.o.e.DefaultOpExecutioner - Cores: [4]; Memory: [1,7GB];
o.n.l.a.o.e.DefaultOpExecutioner - Blas vendor: [OPENBLAS]
```

- Accuracy: 0,9906
- Precision: 0,9905
- Recall: 0,9905
- F1 Score: 0,9905

## How was this patch tested?

Manual test on all touched examples using `runexamples.sh`:

5. MnistClassifier
6. MnistClassifierUI
14. MnistImagePipelineExample
15. MnistImagePipelineExampleAddNeuralNet
17. MnistImagePipelineExampleSave
16. MnistImagePipelineExampleLoad
18. MnistImagePipelineLoadChooser
