### PR TITLE
further improvement on mnist classifier

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/convolution/mnist/MnistClassifier.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/convolution/mnist/MnistClassifier.java
@@ -92,15 +92,15 @@ public class MnistClassifier {
     log.info("Network configuration and training...");
     Map<Integer, Double> lrSchedule = new HashMap<>();
     lrSchedule.put(0, 0.06); // iteration #, learning rate
-    lrSchedule.put(300, 0.05);
-    lrSchedule.put(500, 0.029);
-    lrSchedule.put(700, 0.0044);
-    lrSchedule.put(1000, 0.0011);
+    lrSchedule.put(200, 0.05);
+    lrSchedule.put(600, 0.028);
+    lrSchedule.put(800, 0.0060);
+    lrSchedule.put(1000, 0.001);
 
     MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
         .seed(seed)
         .iterations(iterations)
-        .regularization(true).l1(0.0005)
+        .regularization(true).l2(0.0005)
         .learningRate(.01)
         .learningRateDecayPolicy(LearningRatePolicy.Schedule)
         .learningRateSchedule(lrSchedule) // overrides the rate set in learningRate


### PR DESCRIPTION
## What changes were proposed in this pull request?

Further improvement on MNIST Classifier's accuracy: from 0,9906 to 0,9910.

Changes:

- small changes in learning rate schedule
- switch from l2 to l1 regularization

Result:

 - Accuracy: 0,9910
 - Precision: 0,9910
 - Recall: 0,9909
 - F1 Score: 0,9909

## How was this patch tested?

Manual test with `runexamples.sh` script.
