### PR TITLE
Add maven support for Kotlin code examples

### DIFF
--- a/dl4j-examples/README.md
+++ b/dl4j-examples/README.md
@@ -1,6 +1,6 @@
 # Gradle Kotlin Examples
 
-Open built-in Terminal from the Android Studio or IntelliJ IDEA. 
+Open built-in Terminal from the Android Studio or IntelliJ IDEA.
 If you prefer, use the terminal app on your computer.
 In the terminal window, `cd` to the project root directory `dl4j-examples` if not already in.
 And then type `./gradlew NameOfExampleToRun` to run the examples as shown below.
@@ -17,3 +17,14 @@ MLPMnistTwoLayerExample
 ```
 
 etc.
+
+# Maven Kotlin Examples
+
+Simply import the repo's root pom file as a project into IntelliJ.
+Then add a module via the pom file beside this README.md file.
+
+To run am example
+1. Edit run configurations, create an Application
+2. Specify `Main Class` for example as `org.deeplearning4j.examples.feedforward.mnist.MLPMnistSingleLayerExample`
+3. Specify `Use classpath of module` as `dl4j-examples`
+4. Save and hit run button

--- a/dl4j-examples/pom.xml
+++ b/dl4j-examples/pom.xml
@@ -162,6 +162,12 @@
             <version>${logback.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -224,6 +230,35 @@
             </plugin>
 
             <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${kotlin.version}</version>
+                <!-- https://kotlinlang.org/docs/reference/using-maven.html -->
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals> <goal>compile</goal> </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals> <goal>test-compile</goal> </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
@@ -231,6 +266,28 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
+                <executions>
+                    <!-- Replacing default-compile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals> <goal>compile</goal> </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals> <goal>testCompile</goal> </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/dl4j-examples/src/main/kotlin/org/deeplearning4j/examples/feedforward/mnist/MLPMnistSingleLayerExample.kt
+++ b/dl4j-examples/src/main/kotlin/org/deeplearning4j/examples/feedforward/mnist/MLPMnistSingleLayerExample.kt
@@ -1,22 +1,16 @@
 package org.deeplearning4j.examples.feedforward.mnist
 
-import org.nd4j.linalg.activations.Activation
-import org.nd4j.linalg.dataset.api.iterator.DataSetIterator
 import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator
 import org.deeplearning4j.eval.Evaluation
-import org.deeplearning4j.nn.api.OptimizationAlgorithm
-import org.deeplearning4j.nn.conf.MultiLayerConfiguration
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration
-import org.deeplearning4j.nn.conf.Updater
 import org.deeplearning4j.nn.conf.layers.DenseLayer
 import org.deeplearning4j.nn.conf.layers.OutputLayer
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork
 import org.deeplearning4j.nn.weights.WeightInit
 import org.deeplearning4j.optimize.listeners.ScoreIterationListener
-import org.nd4j.linalg.api.ndarray.INDArray
-import org.nd4j.linalg.dataset.DataSet
+import org.nd4j.linalg.activations.Activation
+import org.nd4j.linalg.learning.config.Nesterovs
 import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction
-import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 /**A Simple Multi Layered Perceptron (MLP) applied to digit classification for
@@ -56,12 +50,12 @@ object MLPMnistSingleLayerExample {
 
         log.info("Build model....")
         val conf = NeuralNetConfiguration.Builder()
-                .seed(rngSeed) //include a random seed for reproducibility
+                .seed(rngSeed.toLong()) //include a random seed for reproducibility
                 // use stochastic gradient descent as an optimization algorithm
-
-
-                .learningRate(0.006) //specify the learning rate
-                .updater(Updater.NESTEROVS).momentum(0.9) //specify the rate of change of the learning rate.
+                .updater(Nesterovs.builder()
+                        .learningRate(0.0006)
+                        .momentum(0.9) //specify the rate of change of the learning rate.
+                        .build())
                 .l2(1e-4)
                 .list()
                 .layer(0, DenseLayer.Builder() //create the first, input layer with xavier initialization

--- a/dl4j-examples/src/main/kotlin/org/deeplearning4j/examples/feedforward/mnist/MLPMnistTwoLayerExample.kt
+++ b/dl4j-examples/src/main/kotlin/org/deeplearning4j/examples/feedforward/mnist/MLPMnistTwoLayerExample.kt
@@ -1,23 +1,17 @@
 package org.deeplearning4j.examples.feedforward.mnist
 
 
-import org.nd4j.linalg.activations.Activation
-import org.nd4j.linalg.dataset.api.iterator.DataSetIterator
 import org.deeplearning4j.datasets.iterator.impl.MnistDataSetIterator
 import org.deeplearning4j.eval.Evaluation
-import org.deeplearning4j.nn.api.OptimizationAlgorithm
-import org.deeplearning4j.nn.conf.MultiLayerConfiguration
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration
-import org.deeplearning4j.nn.conf.Updater
 import org.deeplearning4j.nn.conf.layers.DenseLayer
 import org.deeplearning4j.nn.conf.layers.OutputLayer
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork
 import org.deeplearning4j.nn.weights.WeightInit
 import org.deeplearning4j.optimize.listeners.ScoreIterationListener
-import org.nd4j.linalg.api.ndarray.INDArray
-import org.nd4j.linalg.dataset.DataSet
+import org.nd4j.linalg.activations.Activation
+import org.nd4j.linalg.learning.config.Nesterovs
 import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction
-import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 
@@ -64,13 +58,15 @@ object MLPMnistTwoLayerExample {
 
         log.info("Build model....")
         val conf = NeuralNetConfiguration.Builder()
-                .seed(rngSeed) //include a random seed for reproducibility
+                .seed(rngSeed.toLong()) //include a random seed for reproducibility
                  // use stochastic gradient descent as an optimization algorithm
 
                 .activation(Activation.RELU)
                 .weightInit(WeightInit.XAVIER)
-                .learningRate(rate) //specify the learning rate
-                .updater(Updater.NESTEROVS).momentum(0.98) //specify the rate of change of the learning rate.
+                .updater(Nesterovs.builder()
+                        .learningRate(rate)
+                        .momentum(0.98) //specify the rate of change of the learning rate.
+                        .build())
                 .l2(rate * 0.005) // regularize learning model
                 .list()
                 .layer(0, DenseLayer.Builder() //create the first input layer.

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
         <aws.sdk.version>1.11.109</aws.sdk.version>
         <jackson.version>2.6.6</jackson.version>
         <scala.plugin.version>3.2.2</scala.plugin.version>
+        <kotlin.version>1.2.31</kotlin.version>
+        <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     </properties>
 
     <modules>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow user to import this example repo as a maven project (import via the root pom file) in IntelliJ then run Kotlin code examples

## How was this patch tested?

I have manually tried running these two Kotlin code examples in IntelliJ with project imported as maven project 
* dl4j-examples/dl4j-examples/src/main/kotlin/org/deeplearning4j/examples/feedforward/mnist/MLPMnistSingleLayerExample.kt
* dl4j-examples/dl4j-examples/src/main/kotlin/org/deeplearning4j/examples/feedforward/mnist/MLPMnistTwoLayerExample.kt

and they work well.

![image](https://user-images.githubusercontent.com/161689/38585574-a323fa5c-3d1a-11e8-8369-cf8c797c3e23.png)

![image](https://user-images.githubusercontent.com/161689/38585589-b2e9bc10-3d1a-11e8-8e33-9d0174f58578.png)

