### PR TITLE
Update Word2VecSentimentRNN.java

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/word2vecsentiment/Word2VecSentimentRNN.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/word2vecsentiment/Word2VecSentimentRNN.java
@@ -77,7 +77,7 @@ public class Word2VecSentimentRNN {
         //Set up network configuration
         MultiLayerConfiguration conf = new NeuralNetConfiguration.Builder()
             .seed(seed)
-            .updater(new Adam(2e-2))
+            .updater(new Adam())
             .l2(1e-5)
             .weightInit(WeightInit.XAVIER)
             .gradientNormalization(GradientNormalization.ClipElementWiseAbsoluteValue).gradientNormalizationThreshold(1.0)


### PR DESCRIPTION
Issue fixed while setting updater for MultiLayerConfiguration, Changed the Adam updater constructor call with learning rate as parameter to default constructor call.

## What changes were proposed in this pull request?

In Word2VecSentimentRNN.java, change the new Adam(2e-2) to new Adam(), because the constructor with single param not found in Adam updater class.

## How was this patch tested?

I just did manual test.

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
