### PR TITLE
Normalize data math functions example

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/feedforward/regression/RegressionMathFunctions.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/feedforward/regression/RegressionMathFunctions.java
@@ -1,14 +1,10 @@
 package org.deeplearning4j.examples.feedforward.regression;
 
+import org.deeplearning4j.datasets.iterator.impl.ListDataSetIterator;
 import org.deeplearning4j.examples.feedforward.regression.function.MathFunction;
 import org.deeplearning4j.examples.feedforward.regression.function.SinXDivXMathFunction;
-import org.nd4j.linalg.activations.Activation;
-import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
-import org.deeplearning4j.datasets.iterator.impl.ListDataSetIterator;
-import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
-import org.deeplearning4j.nn.conf.Updater;
 import org.deeplearning4j.nn.conf.layers.DenseLayer;
 import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
@@ -20,8 +16,12 @@ import org.jfree.chart.JFreeChart;
 import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.data.xy.XYSeries;
 import org.jfree.data.xy.XYSeriesCollection;
+import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.dataset.DataSet;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.dataset.api.preprocessor.DataNormalization;
+import org.nd4j.linalg.dataset.api.preprocessor.NormalizerStandardize;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.learning.config.Nesterovs;
 import org.nd4j.linalg.lossfunctions.LossFunctions;
@@ -31,7 +31,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
-/**Example: Train a network to reproduce certain mathematical functions, and plot the results.
+/**
+ * Example: Train a network to reproduce certain mathematical functions, and plot the results.
  * Plotting of the network output occurs every 'plotFrequency' epochs. Thus, the plot shows the accuracy of the network
  * predictions as training progresses.
  * A number of mathematical functions are implemented here.
@@ -56,88 +57,100 @@ public class RegressionMathFunctions {
     public static final Random rng = new Random(seed);
     public static final int numInputs = 1;
     public static final int numOutputs = 1;
+    public static DataNormalization normalizer = new NormalizerStandardize();
 
-
-    public static void main(final String[] args){
+    public static void main(final String[] args) {
 
         //Switch these two options to do different functions with different networks
         final MathFunction fn = new SinXDivXMathFunction();
         final MultiLayerConfiguration conf = getDeepDenseLayerNetworkConfiguration();
 
         //Generate the training data
-        final INDArray x = Nd4j.linspace(-10,10,nSamples).reshape(nSamples, 1);
-        final DataSetIterator iterator = getTrainingData(x,fn,batchSize,rng);
+        final INDArray x = Nd4j.linspace(-40, 40, nSamples).reshape(nSamples, 1);
+        final DataSetIterator iterator = getTrainingData(x, fn, batchSize, rng);
 
         //Create the network
         final MultiLayerNetwork net = new MultiLayerNetwork(conf);
         net.init();
-        net.setListeners(new ScoreIterationListener(1));
+        net.setListeners(new ScoreIterationListener(100));
 
 
         //Train the network on the full data set, and evaluate in periodically
-        final INDArray[] networkPredictions = new INDArray[nEpochs/ plotFrequency];
-        for( int i=0; i<nEpochs; i++ ){
+        final INDArray[] networkPredictions = new INDArray[nEpochs / plotFrequency];
+        for (int i = 0; i < nEpochs; i++) {
             iterator.reset();
             net.fit(iterator);
-            if((i+1) % plotFrequency == 0) networkPredictions[i/ plotFrequency] = net.output(x, false);
+            INDArray output = net.output(x, false);
+            normalizer.revertLabels(output);
+            if ((i + 1) % plotFrequency == 0) networkPredictions[i / plotFrequency] = output;
         }
 
+        normalizer.revertFeatures(x);
+
         //Plot the target data and the network predictions
-        plot(fn,x,fn.getFunctionValues(x),networkPredictions);
+        plot(fn, x, fn.getFunctionValues(x), networkPredictions);
     }
 
-    /** Returns the network configuration, 2 hidden DenseLayers of size 50.
+    /**
+     * Returns the network configuration, 2 hidden DenseLayers of size 50.
      */
     private static MultiLayerConfiguration getDeepDenseLayerNetworkConfiguration() {
         final int numHiddenNodes = 50;
         return new NeuralNetConfiguration.Builder()
-                .seed(seed)
-                .weightInit(WeightInit.XAVIER)
-                .updater(new Nesterovs(learningRate, 0.9))
-                .list()
-                .layer(0, new DenseLayer.Builder().nIn(numInputs).nOut(numHiddenNodes)
-                        .activation(Activation.TANH).build())
-                .layer(1, new DenseLayer.Builder().nIn(numHiddenNodes).nOut(numHiddenNodes)
-                        .activation(Activation.TANH).build())
-                .layer(2, new OutputLayer.Builder(LossFunctions.LossFunction.MSE)
-                        .activation(Activation.IDENTITY)
-                        .nIn(numHiddenNodes).nOut(numOutputs).build())
-                .pretrain(false).backprop(true).build();
+            .seed(seed)
+            .weightInit(WeightInit.XAVIER)
+            .updater(new Nesterovs(learningRate, 0.9))
+            .list()
+            .layer(0, new DenseLayer.Builder().nIn(numInputs).nOut(numHiddenNodes)
+                .activation(Activation.TANH).build())
+            .layer(1, new DenseLayer.Builder().nIn(numHiddenNodes).nOut(numHiddenNodes)
+                .activation(Activation.TANH).build())
+            .layer(2, new OutputLayer.Builder(LossFunctions.LossFunction.MSE)
+                .activation(Activation.IDENTITY)
+                .nIn(numHiddenNodes).nOut(numOutputs).build())
+            .pretrain(false).backprop(true).build();
     }
 
-    /** Create a DataSetIterator for training
-     * @param x X values
-     * @param function Function to evaluate
+    /**
+     * Create a DataSetIterator for training
+     *
+     * @param x         X values
+     * @param function  Function to evaluate
      * @param batchSize Batch size (number of examples for every call of DataSetIterator.next())
-     * @param rng Random number generator (for repeatability)
+     * @param rng       Random number generator (for repeatability)
      */
     private static DataSetIterator getTrainingData(final INDArray x, final MathFunction function, final int batchSize, final Random rng) {
         final INDArray y = function.getFunctionValues(x);
-        final DataSet allData = new DataSet(x,y);
+        final DataSet allData = new DataSet(x, y);
+
+        normalizer.fitLabel(true);
+        normalizer.fit(allData);
+        normalizer.transform(allData);
 
         final List<DataSet> list = allData.asList();
-        Collections.shuffle(list,rng);
-        return new ListDataSetIterator(list,batchSize);
+        Collections.shuffle(list, rng);
+        return new ListDataSetIterator(list, batchSize);
     }
 
     //Plot the data
     private static void plot(final MathFunction function, final INDArray x, final INDArray y, final INDArray... predicted) {
-        final XYSeriesCollection dataSet = new XYSeriesCollection();
-        addSeries(dataSet,x,y,"True Function (Labels)");
 
-        for( int i=0; i<predicted.length; i++ ){
-            addSeries(dataSet,x,predicted[i],String.valueOf(i));
+        final XYSeriesCollection dataSet = new XYSeriesCollection();
+        addSeries(dataSet, x, y, "True Function (Labels)");
+
+        for (int i = 0; i < predicted.length; i++) {
+            addSeries(dataSet, x, predicted[i], String.valueOf(i));
         }
 
         final JFreeChart chart = ChartFactory.createXYLineChart(
-                "Regression Example - " + function.getName(),      // chart title
-                "X",                        // x axis label
-                function.getName() + "(X)", // y axis label
-                dataSet,                    // data
-                PlotOrientation.VERTICAL,
-                true,                       // include legend
-                true,                       // tooltips
-                false                       // urls
+            "Regression Example - " + function.getName(),      // chart title
+            "X",                        // x axis label
+            function.getName() + "(X)", // y axis label
+            dataSet,                    // data
+            PlotOrientation.VERTICAL,
+            true,                       // include legend
+            true,                       // tooltips
+            false                       // urls
         );
 
         final ChartPanel panel = new ChartPanel(chart);
@@ -150,11 +163,11 @@ public class RegressionMathFunctions {
         f.setVisible(true);
     }
 
-    private static void addSeries(final XYSeriesCollection dataSet, final INDArray x, final INDArray y, final String label){
+    private static void addSeries(final XYSeriesCollection dataSet, final INDArray x, final INDArray y, final String label) {
         final double[] xd = x.data().asDouble();
         final double[] yd = y.data().asDouble();
         final XYSeries s = new XYSeries(label);
-        for( int j=0; j<xd.length; j++ ) s.add(xd[j],yd[j]);
+        for (int j = 0; j < xd.length; j++) s.add(xd[j], yd[j]);
         dataSet.addSeries(s);
     }
 }

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/feedforward/regression/RegressionMathFunctions.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/feedforward/regression/RegressionMathFunctions.java
@@ -2,7 +2,13 @@ package org.deeplearning4j.examples.feedforward.regression;
 
 import org.deeplearning4j.datasets.iterator.impl.ListDataSetIterator;
 import org.deeplearning4j.examples.feedforward.regression.function.MathFunction;
+import org.deeplearning4j.examples.feedforward.regression.function.Mul2XMathFunction;
 import org.deeplearning4j.examples.feedforward.regression.function.SinXDivXMathFunction;
+import org.deeplearning4j.examples.feedforward.regression.function.TriangleWaveMathFunction;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.deeplearning4j.datasets.iterator.impl.ListDataSetIterator;
+import org.deeplearning4j.nn.api.OptimizationAlgorithm;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.layers.DenseLayer;
@@ -66,8 +72,8 @@ public class RegressionMathFunctions {
         final MultiLayerConfiguration conf = getDeepDenseLayerNetworkConfiguration();
 
         //Generate the training data
-        final INDArray x = Nd4j.linspace(-40, 40, nSamples).reshape(nSamples, 1);
-        final DataSetIterator iterator = getTrainingData(x, fn, batchSize, rng);
+        final INDArray x = Nd4j.linspace(-10,10,nSamples).reshape(nSamples, 1);
+        final DataSetIterator iterator = getTrainingData(x,fn,batchSize,rng);
 
         //Create the network
         final MultiLayerNetwork net = new MultiLayerNetwork(conf);

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/feedforward/regression/function/Mul2XMathFunction.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/feedforward/regression/function/Mul2XMathFunction.java
@@ -1,0 +1,17 @@
+package org.deeplearning4j.examples.feedforward.regression.function;
+
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+public class Mul2XMathFunction implements MathFunction {
+
+    @Override
+    public INDArray getFunctionValues(INDArray x) {
+        return x.dup().mul(2);
+    }
+
+    @Override
+    public String getName() {
+        return "Mul2XMathFunction";
+    }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add data normalization in the RegressionMathFunctions example. Without this patch if you try to train the net for a math function which generates values greater than 1 or lower than -1, data must be normalized or the following will happen:

- I tried to simulate the function: `f(x) = 2x` (Function implemented here [Mul2XMathFunction.java](https://github.com/aramburu/dl4j-examples/blob/normalizeDataMathFunctionsExample/dl4j-examples/src/main/java/org/deeplearning4j/examples/feedforward/regression/function/Mul2XMathFunction.java))

- If we try to train the net with a range from -100 to 100:
<img width="680" alt="screen shot 2018-06-02 at 02 36 22" src="https://user-images.githubusercontent.com/39844090/40868577-7086dcbe-660e-11e8-9650-534e05c2108f.png">

But if we normalize the data, then works as expected:
<img width="679" alt="screen shot 2018-06-02 at 02 38 55" src="https://user-images.githubusercontent.com/39844090/40868589-8415ab34-660e-11e8-8ad2-c074fbef11a0.png">

## How was this patch tested?

Tested with the other MathFunction implementations.
