### PR TITLE
MnistMLPDistributedExample should use the actual mnist test set

### DIFF
--- a/dl4j-spark-examples/dl4j-spark/src/main/java/org/deeplearning4j/mlp/MnistMLPDistributedExample.java
+++ b/dl4j-spark-examples/dl4j-spark/src/main/java/org/deeplearning4j/mlp/MnistMLPDistributedExample.java
@@ -85,7 +85,7 @@ public class MnistMLPDistributedExample {
         //Load the data into memory then parallelize
         //This isn't a good approach in general - but is simple to use for this example
         DataSetIterator iterTrain = new MnistDataSetIterator(batchSizePerWorker, true, 12345);
-        DataSetIterator iterTest = new MnistDataSetIterator(batchSizePerWorker, true, 12345);
+        DataSetIterator iterTest = new MnistDataSetIterator(batchSizePerWorker, false, 12345);
         List<DataSet> trainDataList = new ArrayList<>();
         List<DataSet> testDataList = new ArrayList<>();
         while (iterTrain.hasNext()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

AFAICT the MnistMLPDistributedExample is currently using the training set as a testing set.

## How was this patch tested?

Manual
