### PR TITLE
Change chars used for pitches and durations so they match ASCII order. 

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/MelodyModelingExample.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/MelodyModelingExample.java
@@ -31,10 +31,11 @@ import java.util.Random;
  * Based closely on LSTMCharModellingExample.java.
  * See the README file in this directory for documentation.
  *
- * @author Alex Black, Donald A. Smith.
+ * @author Donald A. Smith, Alex Black.
  */
 public class MelodyModelingExample {
-    final static String inputSymbolicMelodiesFilename = "bach-melodies-input.txt";
+    final static String inputSymbolicMelodiesFilename = "bach-midi-melodies.txt"; // Same as default for
+    // MidiMelodyExtractor.java
     // Examples:  bach-melodies-input.txt, beatles-melodies-input.txt ,  pop-melodies-input.txt (large)
 
     final static String tmpDir = System.getProperty("java.io.tmpdir");

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/MelodyStrings.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/MelodyStrings.java
@@ -11,12 +11,12 @@ public class MelodyStrings {
     public static final String COMMENT_STRING = "//";
     // The following strings are used to build the symbolic representation of a melody
     // The next two strings contain chars used to indicate pitch deltas.
-    public static final String noteGapCharsPositive = "0123456789abc"; // A pitch delta of "0" indicates delta=0.
-    public static final String noteGapCharsNegative = "ABCDEFGHIJKLM"; // A pitch delta of "A" indicates delta=-1.
+    // We use this ordering of characters so that
+    public static final String noteGapCharsNegative = "MLKJIHGFEDCBA"; // "M" indicates delta=-1. "L" indicates -2,...
+    public static final String noteGapCharsPositive = "NOPQRSTUVWXYZ"; // "N" indicates delta=0. "O" indicates 1, ...
     // R is used to indicate the beginning of a rest
-    public static int durationDeltaParts = 8;
-    public static final String durationChars = "defghijkmnopqrstuvwzyz!@#$%^&*-_"; // 32 divisions.  We omit lower-case L to avoid confusion with one.
-    //                                          12345678901234567890123456789012
+    public static int durationDeltaParts = 8; //12345678901234567890123456789012
+    public static final String durationChars = "]^_`abcdefghijklmnopqrstuvwzyz{|"; // 32 divisions, in ASCII order
     public static final String allValidCharacters = getValidCharacters();
     // 13+13+1+32 = 59 possible characters.
     // 'd' indicates the smallest pitch duration allowed (typically a 1/32 note or so).

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/MelodyStrings.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/MelodyStrings.java
@@ -11,7 +11,7 @@ public class MelodyStrings {
     public static final String COMMENT_STRING = "//";
     // The following strings are used to build the symbolic representation of a melody
     // The next two strings contain chars used to indicate pitch deltas.
-    // We use this ordering of characters so that
+    // We use this ordering of characters so that the pitch gap order is the same as the ASCII order.
     public static final String noteGapCharsNegative = "MLKJIHGFEDCBA"; // "M" indicates delta=-1. "L" indicates -2,...
     public static final String noteGapCharsPositive = "NOPQRSTUVWXYZ"; // "N" indicates delta=0. "O" indicates 1, ...
     // ' ' is used to indicate the beginning of a rest

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/MelodyStrings.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/MelodyStrings.java
@@ -20,7 +20,7 @@ public class MelodyStrings {
     public static String allPitchGapCharsIncludingRest = REST_CHAR + pitchGapCharsNegative + pitchGapCharsPositive;
     // ' ' is used to indicate the beginning of a rest
     public static int durationDeltaParts = 8; //12345678901234567890123456789012
-    public static final String durationChars = "]^_`abcdefghijklmnopqrstuvwzyz{|"; // 32 divisions, in ASCII order
+    public static final String durationChars = "]^_`abcdefghijklmnopqrstuvwxyz{|"; // 32 divisions, in ASCII order
     public static final String allValidCharacters = getValidCharacters();
     // 13+13+1+32 = 59 possible characters.
     // ']' indicates the smallest pitch duration allowed (typically a 1/32 note or so).

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/MelodyStrings.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/MelodyStrings.java
@@ -14,16 +14,16 @@ public class MelodyStrings {
     // We use this ordering of characters so that
     public static final String noteGapCharsNegative = "MLKJIHGFEDCBA"; // "M" indicates delta=-1. "L" indicates -2,...
     public static final String noteGapCharsPositive = "NOPQRSTUVWXYZ"; // "N" indicates delta=0. "O" indicates 1, ...
-    // R is used to indicate the beginning of a rest
+    // ' ' is used to indicate the beginning of a rest
     public static int durationDeltaParts = 8; //12345678901234567890123456789012
     public static final String durationChars = "]^_`abcdefghijklmnopqrstuvwzyz{|"; // 32 divisions, in ASCII order
     public static final String allValidCharacters = getValidCharacters();
     // 13+13+1+32 = 59 possible characters.
-    // 'd' indicates the smallest pitch duration allowed (typically a 1/32 note or so).
-    // 'e' is a duration twice that of 'd'
-    // 'f' is a duration three times that of 'd', etc.
-    // If there is a rest between notes, we append 'R' followed by a char for the duration of the rest.
-    public static final char restChar = 'R';
+    // ']' indicates the smallest pitch duration allowed (typically a 1/32 note or so).
+    // '^' is a duration twice that of ']'
+    // '_' is a duration three times that of ']', etc.
+    // If there is a rest between notes, we append ' ' followed by a char for the duration of the rest.
+    public static final char REST_CHAR = ' ';
 
     /**
      * @return characters that may occur in a valid melody string
@@ -33,10 +33,15 @@ public class MelodyStrings {
         sb.append(noteGapCharsPositive);
         sb.append(noteGapCharsNegative);
         sb.append(durationChars);
-        sb.append('R');
+        sb.append(REST_CHAR);
         return sb.toString();
     }
-
+    public static boolean isDurationChar(char ch) {
+        return ch>=']' && ch <= '|';
+    }
+    public static boolean isPitchChar(char ch) {
+        return ch >= 'A' && ch <= 'Z';
+    }
     public static String convertToMelodyString(List<Note> noteSequence) {
         double averageNoteDuration = computeAverageDuration(noteSequence);
         double durationDelta = averageNoteDuration / durationDeltaParts;
@@ -51,7 +56,7 @@ public class MelodyStrings {
                 long restDuration = note.getStartTick() - previousNote.getEndTick();
                 if (restDuration > 0) {
                     char restDurationChar = computeDurationChar(restDuration, durationDelta);
-                    sb.append(restChar);
+                    sb.append(REST_CHAR);
                     sb.append(restDurationChar);
                 }
                 int pitchGap = note.getPitch() - previousNote.getPitch();

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/MidiMelodyExtractor.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/MidiMelodyExtractor.java
@@ -1,5 +1,7 @@
 package org.deeplearning4j.examples.recurrent.character.melodl4j;
 
+import org.nd4j.util.ArchiveUtils;
+
 import java.io.*;
 import java.net.URL;
 import java.text.NumberFormat;
@@ -720,10 +722,15 @@ public class MidiMelodyExtractor {
             String lastName = outputDirectory.getName();
             String zipFileName = lastName + ".zip";
             String urlPath = "http://truthsite.org/music/" + zipFileName;
-            String outputZipFilePath = tmpDirPathEndingInSlash + zipFileName;
-            File zipFile = new File(outputZipFilePath);
+            String zipFilePath = tmpDirPathEndingInSlash + zipFileName;
+            File zipFile = new File(zipFilePath);
             try {
-                PlayMelodyStrings.copyURLContentsToFile(new URL(urlPath), zipFile);
+                if (zipFile.exists()) {
+                    System.out.println("Using existing " + zipFilePath);
+                } else {
+                    System.out.println("Downloading zipfile from " + urlPath + " to " + zipFilePath);
+                    PlayMelodyStrings.copyURLContentsToFile(new URL(urlPath), zipFile);
+                }
             } catch (Exception e) {
                 System.err.println("Unable to download zip file from " + urlPath + " into " + tmpDirPathEndingInSlash);
                 System.exit(1);
@@ -736,9 +743,10 @@ public class MidiMelodyExtractor {
             }
             try {
                unzip(zipFile, outputDirectoryPath);
+                //ArchiveUtils.unzipFileTo(zipFile.getAbsolutePath(), outputDirectoryPath);
             } catch (Exception e) {
 //                directory.delete();
-                System.err.println("Unable to unzip file from " + outputZipFilePath + " into " + outputDirectoryPath + " due to " + e.getMessage());
+                System.err.println("Unable to unzip file from " + zipFilePath + " into " + outputDirectoryPath + " due to " + e.getMessage());
                 e.printStackTrace();
                 System.exit(1);
             }

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/MidiMelodyExtractor.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/MidiMelodyExtractor.java
@@ -1,13 +1,10 @@
 package org.deeplearning4j.examples.recurrent.character.melodl4j;
 
-import org.nd4j.util.ArchiveUtils;
-
 import java.io.*;
 import java.net.URL;
 import java.text.NumberFormat;
 import java.util.*;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 import javax.sound.midi.InvalidMidiDataException;
 import javax.sound.midi.MidiEvent;
@@ -690,8 +687,8 @@ public class MidiMelodyExtractor {
         }
         bos.close();
     }
-    private static void unzip(File file, String outputDirectory) throws IOException {
-        ZipInputStream zipIn = new ZipInputStream(new FileInputStream(file));
+    private static void unzip(File zipFile, String outputDirectory) throws IOException {
+        ZipInputStream zipIn = new ZipInputStream(new FileInputStream(zipFile));
         ZipEntry zipEntry = zipIn.getNextEntry();
         while (zipEntry != null) {
             String filePath = outputDirectory + File.separator + zipEntry.getName();
@@ -724,9 +721,9 @@ public class MidiMelodyExtractor {
             String zipFileName = lastName + ".zip";
             String urlPath = "http://truthsite.org/music/" + zipFileName;
             String outputZipFilePath = tmpDirPathEndingInSlash + zipFileName;
-            File midiFile = new File(outputZipFilePath);
+            File zipFile = new File(outputZipFilePath);
             try {
-                PlayMelodyStrings.copyURLContentsToFile(new URL(urlPath), midiFile);
+                PlayMelodyStrings.copyURLContentsToFile(new URL(urlPath), zipFile);
             } catch (Exception e) {
                 System.err.println("Unable to download zip file from " + urlPath + " into " + tmpDirPathEndingInSlash);
                 System.exit(1);
@@ -738,7 +735,7 @@ public class MidiMelodyExtractor {
                 System.exit(1);
             }
             try {
-               unzip(midiFile, outputDirectoryPath);
+               unzip(zipFile, outputDirectoryPath);
             } catch (Exception e) {
 //                directory.delete();
                 System.err.println("Unable to unzip file from " + outputZipFilePath + " into " + outputDirectoryPath + " due to " + e.getMessage());

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/PlayMelodyStrings.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/PlayMelodyStrings.java
@@ -1,7 +1,5 @@
 package org.deeplearning4j.examples.recurrent.character.melodl4j;
 
-import play.Play;
-
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
@@ -330,11 +328,11 @@ public class PlayMelodyStrings {
 
     // return -1 if it's not a pitch
     private static int getPitchDelta(char ch) {
-        int index = MelodyStrings.noteGapCharsPositive.indexOf(ch);
+        int index = MelodyStrings.pitchGapCharsPositive.indexOf(ch);
         if (index >= 0) {
             return index;
         }
-        index = MelodyStrings.noteGapCharsNegative.indexOf(ch);
+        index = MelodyStrings.pitchGapCharsNegative.indexOf(ch);
         if (index < 0) {
             System.err.println("WARNING: invalid pitch char: " + ch);
             return -1;
@@ -399,7 +397,7 @@ public class PlayMelodyStrings {
                 } else {
                     System.err.println(ch + " is invalid as a duration char"); // Badly formed melody string
                 }
-            } else if (MelodyStrings.isPitchChar(ch)) {
+            } else if (MelodyStrings.isPitchCharOrRest(ch)) {
                 index++;
                 int pitchDelta = getPitchDelta(ch);
                 lastRawNote += pitchDelta;

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/PlayMelodyStrings.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/PlayMelodyStrings.java
@@ -336,6 +336,7 @@ public class PlayMelodyStrings {
         }
         index = MelodyStrings.noteGapCharsNegative.indexOf(ch);
         if (index < 0) {
+            System.err.println("WARNING: invalid pitch char: " + ch);
             return -1;
         }
         return -(index + 1);
@@ -370,7 +371,6 @@ public class PlayMelodyStrings {
         // Next: are  restDuration, pitch, noteDuration
         int channel = 0;
         int velocity = 95;
-        int track = 2;
         final int resolution = 480;
         final int resolutionDelta = resolution / 16;
         int index = 0; //getIndexOfFirstPitchDuration(line);
@@ -387,6 +387,7 @@ public class PlayMelodyStrings {
         }
         int noteDurationInTicks = 0;
 
+        // index should point at a pitch char
         while (index < melody.length() - 1) {
             char ch = melody.charAt(index);
             if (ch == MelodyStrings.REST_CHAR) {
@@ -396,26 +397,26 @@ public class PlayMelodyStrings {
                     tick += getDurationInTicks(ch, resolutionDelta);
                     index++;
                 } else {
-                    System.out.print(MelodyStrings.REST_CHAR); // Badly formed melody string
+                    System.err.println(ch + " is invalid as a duration char"); // Badly formed melody string
                 }
-            } else if (MelodyStrings.isDurationChar(ch)) {
+            } else if (MelodyStrings.isPitchChar(ch)) {
                 index++;
                 int pitchDelta = getPitchDelta(ch);
                 lastRawNote += pitchDelta;
                 while (lastRawNote < 30) {
                     System.out.print('<');
-                    lastRawNote += 12; // This is a hack to prevent melodies from becoming inaudible
+                    lastRawNote += 12; // This prevents pitches from becoming too low
                 }
                 while (lastRawNote >= 80) {
                     System.out.print('>');
-                    lastRawNote -= 12; // This is a hack to prevent melodies from becoming inaudible
+                    lastRawNote -= 12; // This prevents pitches from becoming too high
                 }
                 ch = melody.charAt(index);
                 if (MelodyStrings.isDurationChar(ch)) {
                     noteDurationInTicks = getDurationInTicks(ch, resolutionDelta);
                     index++;
                 } else {
-                    System.out.print('D'); // Badly formed melody string
+                    System.err.println("Expected duration char, got " + ch); // Badly formed melody string
                     noteDurationInTicks = 4 * resolutionDelta;
                 }
                 //                 Note(int pitch, long startTick, int instrument, int channel, int velocity)
@@ -424,7 +425,7 @@ public class PlayMelodyStrings {
                 ns.add(note);
                 tick += noteDurationInTicks;
             } else {
-                System.out.print(ch);
+                System.err.println("Error char: " + ch);
                 index++;
             }
         }
@@ -551,6 +552,7 @@ public class PlayMelodyStrings {
     public static void main(String[] args) {
 //        String filename="beatles-melodies-input.txt";
 //        MelodyModelingExample.makeSureFileIsInTmpDir(filename);
+        args = new String[] {"c:/users/Don Smith/AppData/Local/Temp/bach-midi-melodies.txt"};
         try {
             String pathToMelodiesFile = args.length == 0 ? getPathToExampleMelodiesFile() : args[0];
             playMelodies(pathToMelodiesFile, 30); /// Note: by default it plays 30 seconds of each melody

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/README.md
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/README.md
@@ -51,6 +51,8 @@ See http://www.asimovinstitute.org/analyzing-deep-learning-tools-music/, and htt
 20.  The melody strings composed by the neural network sometimes have invalid syntax (especially at the beginning of training). For example, in a valid melody string, each pitch character is followed by a duration character. PlayMelodyStrings.java will ignore invalid characters in melody strings.
 21.  You can download symbolic music files from [http://truthsite.org/music/bach-melodies.txt](http://truthsite.org/music/bach-melodies.txt) and [http://truthsite.org/music/pop-melodies.txt](http://truthsite.org/music/pop-melodies.txt) .
 22.  You can download some MIDI files from [http://truthsite.org/music/bach-midi.zip](http://truthsite.org/music/bach-midi.zip), [http://truthsite.org/music/pop-midi.zip](http://truthsite.org/music/pop-midi.zip), from [http://musedata.org](http://musedata.org), or from the huge Lakh MIDI Dataset at [http://colinraffel.com/projects/lmd/](http://colinraffel.com/projects/lmd/).
+23.  By default MidiMelodyExtractor.java downloads and extracts MIDI files from bach-midi.zip into bach-midi/ in your temporary directory.  It then extracts melodies into bach-midi-melodies.txt in your temporary directory.
+24.  By default, MelodyModelingExample.java learns melodies from bach-midi-melodies.txt.
 
 * * *
 
@@ -59,7 +61,7 @@ See http://www.asimovinstitute.org/analyzing-deep-learning-tools-music/, and htt
 1.  Represent durations numerically, not symbolically. Currently, both pitches and durations are represented symbolically (as characters), not numerically. This makes sense for pitches probably, since the qualitative feel of a C followed by a G is quite different from the qualitative feel of a C followed by a G#. Likewise, following a C, a G is more similar to a E than to a G#; both E and G are notes in a C major chord. But for tempos, a 32d note is more similar to a 16th note than to a quarter note, etc.
 2.  Explore different activation functions, numbers of layers, and network hyper-parameters.
 3.  Run larger experiments on more MIDI files (e.g., from the Lakh MIDI Dataset at [http://colinraffel.com/projects/lmd](http://colinraffel.com/projects/lmd)).
-4.  Handle polyphonic music: chords and harmony.
+4.  Handle polyphonic music: chords and harmony. (I did this for two-part harmonies in ../harmonies in dl4j-examples.)
 5.  Handle gradations of volume, as well as other effects such as vibrato and pitch bend.
 6.  Learn different melodies for different instruments.
 7.  Make an interactive app that lets you "prime" the neural network with a melody -- via a real or virtual (piano) keyboard -- similar to <tt>generationInitialization</tt> in <tt>LSTMCharModellingExample</tt>.


### PR DESCRIPTION
## What changes were proposed in this pull request?

I changed the characters used to represent pitch deltas and durations so that the order of pitch deltas and the order of durations match the ASCII order. This might make learning easier (depending on the learning algorithm).    

Also, I noticed that if the zip file of midi files has a sub-directory, the extractor in ArchiveUtils didn't seem to work: the parent directory wasn't created.  So I made a local method that does the extraction. This became apparent when I updated the bach-midi.zip file and noticed that extraction failed.   Probably org.nd4j.util.ArchiveUtils should be changed to reflect the same fix, but that's part of a different git project.

## How was this patch tested?

I ran the example end-to-end:  downloading and extracting MIDI files,  extracting melodies, learning melodies, and playing melodies.

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
