### PR TITLE
minor fix : changed jpg to .jpg for more intuition + comments added

### DIFF
--- a/datavec-examples/src/main/java/org/datavec/inputsplit/Ex02_CollectionSplitExample.java
+++ b/datavec-examples/src/main/java/org/datavec/inputsplit/Ex02_CollectionSplitExample.java
@@ -21,8 +21,10 @@ public class Ex02_CollectionSplitExample {
 
         /*
           Creating a FileSplit this just to receive a list of URIs. From those URIs we'll create the CollectionInputSplit.
+          Specify the allowed extensions using an array of String where each entry denotes an extension to be included.
+          Added extensions with an intuitive approach. eg: ".jpg", ".png" etc.
          */
-        FileSplit fileSplit = new FileSplit(directoryToLook, new String[]{"jpg"}, false);
+        FileSplit fileSplit = new FileSplit(directoryToLook, new String[]{".jpg"}, false);
 
         /*
           Now you can create the CollectionInputSplit and print it as follows.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is in reference to a minor change where "jpg" is changed to ".jpg".
Other InputSplit examples followed the same approach. Updated accordingly to avoid any confusion and to follow more intuitive approach.

Only 1 file has changed: "Ex02_CollectionSplitExample.java"


## How was this patch tested?

Manual test was performed. Here is the snapshot for results without any error.
![image](https://user-images.githubusercontent.com/517415/52943164-83251c80-3392-11e9-821e-766d57afd95b.png)


Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
