### PR TITLE
Arbiter : added two genetic hyperparameter optimization examples

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/arbiter/genetic/BaseGeneticHyperparameterOptimizationExample.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/arbiter/genetic/BaseGeneticHyperparameterOptimizationExample.java
@@ -1,0 +1,79 @@
+package org.deeplearning4j.examples.arbiter.genetic;
+
+import org.deeplearning4j.arbiter.ComputationGraphSpace;
+import org.deeplearning4j.arbiter.optimize.api.OptimizationResult;
+import org.deeplearning4j.arbiter.optimize.api.saving.ResultReference;
+import org.deeplearning4j.arbiter.optimize.generator.GeneticSearchCandidateGenerator;
+import org.deeplearning4j.arbiter.optimize.generator.genetic.Chromosome;
+import org.deeplearning4j.arbiter.optimize.generator.genetic.population.PopulationListener;
+import org.deeplearning4j.arbiter.optimize.generator.genetic.population.PopulationModel;
+import org.deeplearning4j.arbiter.optimize.runner.IOptimizationRunner;
+import org.deeplearning4j.arbiter.scoring.impl.EvaluationScoreFunction;
+import org.deeplearning4j.eval.Evaluation;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+
+import java.util.List;
+
+/**
+ * This is a basic hyperparameter optimization example using the genetic candidate generator of Arbiter to conduct a search.
+ * This example illustrate how use the GeneticSearchCandidateGenerator with its default behavior: In short, it will
+ * initially generate 20 random candidates and then start breeding (crossover genes of two parents and mutate some genes) candidates together. Then, when the population
+ * hits its default max size (30), the population is culled back to 20 before adding the new candidate.
+ *
+ * @author Alexandre Boulanger
+ */
+
+public class BaseGeneticHyperparameterOptimizationExample {
+
+    public static void main(String[] args) throws Exception {
+
+        ComputationGraphSpace cgs = GeneticSearchExampleConfiguration.GetGraphConfiguration();
+
+        EvaluationScoreFunction scoreFunction = new EvaluationScoreFunction(Evaluation.Metric.F1);
+
+        // This is where we create the GeneticSearchCandidateGenerator with its default behavior:
+        //  - a population that fits 30 candidates and is culled back to 20 when it overflows
+        //  - new candidates are generated with a probability of 85% of being the result of breeding (a k-point crossover with 1 to 4 points)
+        //  - the new candidate have a probability of 0.5% of sustaining a random mutation on one of its genes.
+        GeneticSearchCandidateGenerator candidateGenerator = new GeneticSearchCandidateGenerator.Builder(cgs, scoreFunction).build();
+
+        // Let's have a listener to print the population size after each evaluation.
+        PopulationModel populationModel = candidateGenerator.getPopulationModel();
+        populationModel.addListener(new ExamplePopulationListener());
+
+        IOptimizationRunner runner = GeneticSearchExampleConfiguration.BuildRunner(candidateGenerator, scoreFunction);
+
+        //Start the hyperparameter optimization
+        runner.execute();
+
+        //Print out some basic stats regarding the optimization procedure
+        String s = "Best score: " + runner.bestScore() + "\n" +
+            "Index of model with best score: " + runner.bestScoreCandidateIndex() + "\n" +
+            "Number of configurations evaluated: " + runner.numCandidatesCompleted() + "\n";
+        System.out.println(s);
+
+
+        //Get all results, and print out details of the best result:
+        int indexOfBestResult = runner.bestScoreCandidateIndex();
+        List<ResultReference> allResults = runner.getResults();
+
+        OptimizationResult bestResult = allResults.get(indexOfBestResult).getResult();
+        ComputationGraph bestModel = (ComputationGraph) bestResult.getResultReference().getResultModel();
+
+        System.out.println("\n\nConfiguration of best model:\n");
+        System.out.println(bestModel.getConfiguration().toJson());
+    }
+
+    public static class ExamplePopulationListener implements PopulationListener {
+
+        @Override
+        public void onChanged(List<Chromosome> population) {
+            double best = population.get(0).getFitness();
+            double average = population.stream()
+                .mapToDouble(c -> c.getFitness())
+                .average()
+                .getAsDouble();
+            System.out.println(String.format("\nPopulation size is %1$s, best score is %2$s, average score is %3$s", population.size(), best, average));
+        }
+    }
+}

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/arbiter/genetic/CustomGeneticHyperparameterOptimizationExample.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/arbiter/genetic/CustomGeneticHyperparameterOptimizationExample.java
@@ -1,0 +1,158 @@
+package org.deeplearning4j.examples.arbiter.genetic;
+
+import org.apache.commons.math3.random.JDKRandomGenerator;
+import org.apache.commons.math3.random.RandomGenerator;
+import org.apache.commons.math3.random.SynchronizedRandomGenerator;
+import org.deeplearning4j.arbiter.ComputationGraphSpace;
+import org.deeplearning4j.arbiter.optimize.api.OptimizationResult;
+import org.deeplearning4j.arbiter.optimize.api.saving.ResultReference;
+import org.deeplearning4j.arbiter.optimize.generator.GeneticSearchCandidateGenerator;
+import org.deeplearning4j.arbiter.optimize.generator.genetic.Chromosome;
+import org.deeplearning4j.arbiter.optimize.generator.genetic.crossover.CrossoverOperator;
+import org.deeplearning4j.arbiter.optimize.generator.genetic.crossover.KPointCrossover;
+import org.deeplearning4j.arbiter.optimize.generator.genetic.crossover.parentselection.TwoParentSelection;
+import org.deeplearning4j.arbiter.optimize.generator.genetic.culling.CullOperator;
+import org.deeplearning4j.arbiter.optimize.generator.genetic.culling.LeastFitCullOperator;
+import org.deeplearning4j.arbiter.optimize.generator.genetic.population.PopulationListener;
+import org.deeplearning4j.arbiter.optimize.generator.genetic.population.PopulationModel;
+import org.deeplearning4j.arbiter.optimize.generator.genetic.selection.GeneticSelectionOperator;
+import org.deeplearning4j.arbiter.optimize.generator.genetic.selection.SelectionOperator;
+import org.deeplearning4j.arbiter.optimize.runner.IOptimizationRunner;
+import org.deeplearning4j.arbiter.scoring.impl.EvaluationScoreFunction;
+import org.deeplearning4j.eval.Evaluation;
+import org.deeplearning4j.nn.graph.ComputationGraph;
+
+import java.util.List;
+
+/**
+ * In this hyperparameter optimization example, we change the default behavior of the genetic candidate generator.
+ * All parts of the genetic candidate generator can be changed either by changing the parameters of the default
+ * implementations, or by supplying your own implementation.
+ * Here, we'll use an alternate parent selection and culling behaviors.
+ *
+ * @author Alexandre Boulanger
+ */
+
+public class CustomGeneticHyperparameterOptimizationExample {
+
+    public static void main(String[] args) throws Exception {
+
+        ComputationGraphSpace cgs = GeneticSearchExampleConfiguration.GetGraphConfiguration();
+
+        EvaluationScoreFunction scoreFunction = new EvaluationScoreFunction(Evaluation.Metric.F1);
+
+        // The ExampleCullOperator extends the default cull operator (least fit) to include an artificial predator.
+        CullOperator cullOperator = new ExampleCullOperator();
+        PopulationModel populationModel = new PopulationModel.Builder()
+            .cullOperator(cullOperator)
+            .build();
+
+        // We'll use the k-point crossover with our custom implementation of the parent selection. Our implementation
+        // will make sure that one of the parent is one of the best 5 candidate of the population.
+        TwoParentSelection parentSelection = new ExampleParentSelection();
+        CrossoverOperator crossoverOperator = new KPointCrossover.Builder()
+            .parentSelection(parentSelection)
+            .build() ;
+
+        // The selection operator is what generates new candidates. The default implementation generates random candidates
+        // when the population is below a certain size (the maximum size minus the cull ratio) and uses crossover + mutation
+        // when enough candidates are in the population.
+        // Here, we tell the default selection operator to use our crossover implementation.
+        SelectionOperator selectionOperator = new GeneticSelectionOperator.Builder()
+            .crossoverOperator(crossoverOperator)
+            .build();
+
+        // This is where we create the GeneticSearchCandidateGenerator with its default behavior:
+        GeneticSearchCandidateGenerator candidateGenerator = new GeneticSearchCandidateGenerator.Builder(cgs, scoreFunction)
+            .populationModel(populationModel)
+            .selectionOperator(selectionOperator)
+            .build();
+
+        // Let's have a listener to print the population size after each evaluation.
+        populationModel.addListener(new ExamplePopulationListener());
+
+        IOptimizationRunner runner = GeneticSearchExampleConfiguration.BuildRunner(candidateGenerator, scoreFunction);
+
+        //Start the hyperparameter optimization
+        runner.execute();
+
+        //Print out some basic stats regarding the optimization procedure
+        String s = "Best score: " + runner.bestScore() + "\n" +
+            "Index of model with best score: " + runner.bestScoreCandidateIndex() + "\n" +
+            "Number of configurations evaluated: " + runner.numCandidatesCompleted() + "\n";
+        System.out.println(s);
+
+
+        //Get all results, and print out details of the best result:
+        int indexOfBestResult = runner.bestScoreCandidateIndex();
+        List<ResultReference> allResults = runner.getResults();
+
+        OptimizationResult bestResult = allResults.get(indexOfBestResult).getResult();
+        ComputationGraph bestModel = (ComputationGraph) bestResult.getResultReference().getResultModel();
+
+        System.out.println("\n\nConfiguration of best model:\n");
+        System.out.println(bestModel.getConfiguration().toJson());
+
+    }
+
+    // This is an example of a custom behavior for the genetic algorithm. We force one of the parent to be one of the
+    // best 5 candidates of the population.
+    public static class ExampleParentSelection extends TwoParentSelection {
+        private final RandomGenerator rng = new SynchronizedRandomGenerator(new JDKRandomGenerator());
+
+        @Override
+        public double[][] selectParents() {
+            double[][] parents = new double[2][];
+
+            // Select the first parent among the best 5 of the population. The population is always sorted -- the lower
+            // the index, the better is the candidate.
+            int parent1Idx = rng.nextInt(5);
+
+            // The other parent is anyone in the population except the one selected above
+            int parent2Idx;
+            do {
+                parent2Idx = rng.nextInt(population.size());
+            } while (parent1Idx == parent2Idx);
+
+            parents[0] = population.get(parent1Idx).getGenes();
+            parents[1] = population.get(parent2Idx).getGenes();
+
+            return parents;
+        }
+    }
+
+    // Here we extend the behavior of the default cull operator (least fit) to include an artificial predator.
+    // When the population is culled, an additional random number (0, 1 or 2) of elements are removed. These elements
+    // will be replaced with random candidates by the genetic selection operation.
+    // This is probably not the best idea in terms of convergence but it is a good way to demonstrate how one can change
+    // the genetic search algorithm's behavior
+    public static class ExampleCullOperator extends LeastFitCullOperator {
+        private final RandomGenerator rng = new SynchronizedRandomGenerator(new JDKRandomGenerator());
+
+        @Override
+        public void cullPopulation() {
+            super.cullPopulation();
+
+            // Remove between 0 and 2 candidates that falls prey to a 'predator'
+            int preyCount = rng.nextInt(3);
+            for(int i = 0; i < preyCount; ++i) {
+                int preyIdx = rng.nextInt(population.size());
+                population.remove(preyIdx);
+            }
+            System.out.println(String.format("Randomly removed %1$s candidate(s).", preyCount));
+        }
+    }
+
+    public static class ExamplePopulationListener implements PopulationListener {
+
+        @Override
+        public void onChanged(List<Chromosome> population) {
+            double best = population.get(0).getFitness();
+            double average = population.stream()
+                .mapToDouble(Chromosome::getFitness)
+                .average()
+                .getAsDouble();
+            System.out.println(String.format("\nPopulation size is %1$s, best score is %2$s, average score is %3$s", population.size(), best, average));
+        }
+    }
+}

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/arbiter/genetic/GeneticSearchExampleConfiguration.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/arbiter/genetic/GeneticSearchExampleConfiguration.java
@@ -1,0 +1,149 @@
+package org.deeplearning4j.examples.arbiter.genetic;
+
+import org.deeplearning4j.arbiter.ComputationGraphSpace;
+import org.deeplearning4j.arbiter.conf.updater.AdamSpace;
+import org.deeplearning4j.arbiter.conf.updater.schedule.StepScheduleSpace;
+import org.deeplearning4j.arbiter.layers.DenseLayerSpace;
+import org.deeplearning4j.arbiter.layers.OutputLayerSpace;
+import org.deeplearning4j.arbiter.optimize.api.CandidateGenerator;
+import org.deeplearning4j.arbiter.optimize.api.ParameterSpace;
+import org.deeplearning4j.arbiter.optimize.api.data.DataSource;
+import org.deeplearning4j.arbiter.optimize.api.saving.ResultSaver;
+import org.deeplearning4j.arbiter.optimize.api.score.ScoreFunction;
+import org.deeplearning4j.arbiter.optimize.api.termination.MaxCandidatesCondition;
+import org.deeplearning4j.arbiter.optimize.api.termination.TerminationCondition;
+import org.deeplearning4j.arbiter.optimize.config.OptimizationConfiguration;
+import org.deeplearning4j.arbiter.optimize.parameter.continuous.ContinuousParameterSpace;
+import org.deeplearning4j.arbiter.optimize.parameter.discrete.DiscreteParameterSpace;
+import org.deeplearning4j.arbiter.optimize.parameter.integer.IntegerParameterSpace;
+import org.deeplearning4j.arbiter.optimize.runner.IOptimizationRunner;
+import org.deeplearning4j.arbiter.optimize.runner.LocalOptimizationRunner;
+import org.deeplearning4j.arbiter.saver.local.FileModelSaver;
+import org.deeplearning4j.arbiter.task.ComputationGraphTaskCreator;
+import org.deeplearning4j.datasets.iterator.impl.EmnistDataSetIterator;
+import org.deeplearning4j.nn.api.OptimizationAlgorithm;
+import org.deeplearning4j.nn.conf.BackpropType;
+import org.deeplearning4j.nn.weights.WeightInit;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.dataset.api.iterator.DataSetIterator;
+import org.nd4j.linalg.learning.config.IUpdater;
+import org.nd4j.linalg.lossfunctions.LossFunctions;
+import org.nd4j.linalg.schedule.ScheduleType;
+
+import java.io.File;
+import java.util.Properties;
+
+public class GeneticSearchExampleConfiguration {
+
+    public static ComputationGraphSpace GetGraphConfiguration() {
+        int inputSize = 784;
+        int outputSize = 47;
+
+        // First, we setup the hyperspace parameters. These are the values which will change, breed and mutate
+        // while attempting to find the best candidate.
+        DiscreteParameterSpace<Activation> activationSpace = new DiscreteParameterSpace(new Activation[] {
+            Activation.ELU,
+            Activation.RELU,
+            Activation.LEAKYRELU,
+            Activation.TANH,
+            Activation.SELU,
+            Activation.HARDSIGMOID
+        });
+        IntegerParameterSpace[] layersParametersSpace = new IntegerParameterSpace[] {
+            new IntegerParameterSpace(outputSize, inputSize),
+            new IntegerParameterSpace(outputSize, inputSize),
+        };
+        ParameterSpace<IUpdater> updaterSpace = AdamSpace.withLRSchedule(new StepScheduleSpace(ScheduleType.EPOCH, new ContinuousParameterSpace(0.0, 0.1), 0.5, 2));
+        ParameterSpace<Double> l2Space = new ContinuousParameterSpace(0.0, 0.01);
+        ParameterSpace<Double> dropoutSpace = new ContinuousParameterSpace(0.0, 1.0);
+
+        // Then we plug our hyperspace parameters in our model configuration -- a dense layer net with an input layer,
+        // 2 hidden layers and an output layer.
+        ComputationGraphSpace.Builder builder = new ComputationGraphSpace.Builder()
+            .seed(123)
+            .activation(activationSpace)
+            .weightInit(WeightInit.XAVIER)
+            .updater(updaterSpace)
+            .l2(l2Space)
+            .dropOut(dropoutSpace)
+            .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+            .addInputs("in")
+            .addLayer("0",new DenseLayerSpace.Builder().nIn(inputSize).nOut(layersParametersSpace[0]).build(),"in");
+        for(int i = 1; i < layersParametersSpace.length; ++i) {
+            builder = builder.addLayer(String.valueOf(i), new DenseLayerSpace.Builder().nIn(layersParametersSpace[i-1]).nOut(layersParametersSpace[i]).build(), String.valueOf(i - 1));
+        }
+        builder = builder.addLayer("out", new OutputLayerSpace.Builder()
+            .nIn(layersParametersSpace[layersParametersSpace.length - 1])
+            .nOut(outputSize)
+            .lossFunction(LossFunctions.LossFunction.MCXENT)
+            .activation(Activation.SOFTMAX)
+            .build(), String.valueOf(layersParametersSpace.length - 1))
+            .setOutputs("out")
+            .backpropType(BackpropType.Standard)
+            .numEpochs(10);
+        return builder.build();
+    }
+
+    public static IOptimizationRunner BuildRunner(CandidateGenerator candidateGenerator, ScoreFunction scoreFunction) {
+        Class<? extends DataSource> dataSourceClass = ExampleDataSource.class;
+        Properties dataSourceProperties = new Properties();
+        dataSourceProperties.setProperty("minibatchSize", "1024");
+
+        TerminationCondition[] terminationConditions = {
+            new MaxCandidatesCondition(100)};
+
+        String baseSaveDirectory = "arbiterExample/";
+        File f = new File(baseSaveDirectory);
+        if (f.exists()) f.delete();
+        f.mkdir();
+        ResultSaver modelSaver = new FileModelSaver(baseSaveDirectory);
+
+        OptimizationConfiguration configuration = new OptimizationConfiguration.Builder()
+            .candidateGenerator(candidateGenerator)
+            .dataSource(dataSourceClass,dataSourceProperties)
+            .scoreFunction(scoreFunction)
+            .terminationConditions(terminationConditions)
+            .modelSaver(modelSaver)
+            .build();
+
+        return new LocalOptimizationRunner(configuration, new ComputationGraphTaskCreator());
+    }
+
+    public static class ExampleDataSource implements DataSource {
+        private int minibatchSize;
+
+        public ExampleDataSource() {
+
+        }
+
+        @Override
+        public void configure(Properties properties) {
+            this.minibatchSize = Integer.parseInt(properties.getProperty("minibatchSize", "16"));
+        }
+
+        @Override
+        public Object trainData() {
+            try {
+                return new EmnistDataSetIterator(EmnistDataSetIterator.Set.BALANCED, minibatchSize, true, 12345);
+
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Object testData() {
+            try {
+                return new EmnistDataSetIterator(EmnistDataSetIterator.Set.BALANCED, minibatchSize, false, 12345);
+
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Class<?> getDataType() {
+            return DataSetIterator.class;
+        }
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

I added 2 examples demonstrating how to use the GeneticSearchCandidateGenerator. The first one is the basic way to use it with all default settings. The other one is more complex and overrides several behaviors.

Note : Currently, these examples need the SNAPSHOT builds.