### PR TITLE
fix some LGTM alerts

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/convolution/captcharecognition/MultiRecordDataSetIterator.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/convolution/captcharecognition/MultiRecordDataSetIterator.java
@@ -38,7 +38,7 @@ public class MultiRecordDataSetIterator implements MultiDataSetIterator {
 
     @Override
     public void setPreProcessor(MultiDataSetPreProcessor multiDataSetPreProcessor) {
-        this.preProcessor = preProcessor;
+        this.preProcessor = multiDataSetPreProcessor;
     }
 
     @Override

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/Note.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/character/melodl4j/Note.java
@@ -6,6 +6,8 @@ import javax.sound.midi.MidiMessage;
 import javax.sound.midi.ShortMessage;
 import javax.sound.midi.Track;
 
+import com.google.common.base.Objects;
+
 public class Note implements Comparable<Note> {
     private final int pitch;
     private final long startTick;
@@ -78,9 +80,20 @@ public class Note implements Comparable<Note> {
     }
     @Override
     public boolean equals(Object obj) {
+    	if (obj == null) {
+    		return false;
+    	} else if (! (obj instanceof Note)) {
+    		return false;
+    	}
         Note other=(Note)obj;
-        return startTick==other.startTick  && pitch==other.pitch && channel==other.channel;
+        return startTick==other.startTick  && pitch==other.pitch && Objects.equal(channel, other.channel);
     }
+
+    @Override
+    public int hashCode() {
+    	return Objects.hashCode(startTick, pitch, channel);
+    }
+
     public void addMidiEvents(Track track) throws InvalidMidiDataException {
         MidiMessage midiMessageStart=new ShortMessage(ShortMessage.NOTE_ON,channel,pitch,velocity);
         track.add(new MidiEvent(midiMessageStart,startTick));

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/encdec/EncoderDecoderLSTM.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/encdec/EncoderDecoderLSTM.java
@@ -419,7 +419,7 @@ public class EncoderDecoderLSTM {
         dict.put("<go>", 2.0);
         revDict.put(2.0, "<go>");
         for (char c : CHARS.toCharArray()) {
-            if (!dict.containsKey(c)) {
+            if (!dict.containsKey(String.valueOf(c))) {
                 dict.put(String.valueOf(c), idx);
                 revDict.put(idx, String.valueOf(c));
                 ++idx;

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/processlottery/LotteryCombinationDataSetReader.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/processlottery/LotteryCombinationDataSetReader.java
@@ -56,7 +56,7 @@ public class LotteryCombinationDataSetReader extends BaseDataSetReader  {
     //based on the lottery rule,here will the openning lottery date and term switch to the long integer
     //if anyone need extend this model, maybe you can use the method
     private String decorateRecordData(String line) {
-        if (line == null && line.isEmpty()) {
+        if (line == null || line.isEmpty()) {
             return null;
         }
         String[] strArr = line.split(",");

--- a/dl4j-spark-examples/dl4j-spark/src/main/java/org/deeplearning4j/patent/preprocessing/JSoupXmlParser.java
+++ b/dl4j-spark-examples/dl4j-spark/src/main/java/org/deeplearning4j/patent/preprocessing/JSoupXmlParser.java
@@ -86,7 +86,7 @@ public class JSoupXmlParser {
             Element e2 = e.first();
             Elements mainClassification = e2.select("main-classification");
             if (mainClassification == null || mainClassification.size() == 0) {
-                log.warn("Skipping patent {} in document - no main classification");
+                log.warn("Skipping patent {} in document - no main classification", patent);
                 return null;
             }
             String main = e2.select("main-classification").outerHtml().replaceAll("\n", "")


### PR DESCRIPTION
I work for Semmle, the company behind LGTM. I noticed some alerts that were raised during LGTM analysis of dl4j-examples, and fixed some of them. Specifically,
- `Self assignment` in MultiRecordDataSetIterator
- `Type mismatch on container access` in EncoderDecoderLSTM
- `Missing format argument` in JSoupXmlParser
- `Dereferenced variable is always null` in LotteryCombinationDataSetReader
- `Hashed value without hashCode definition` in MidiMusicExtractor and MidiMelodyExtractor (fixed by defining hashCode in Note)
- `Reference equality check on boxed types` in Note
- `Equals does not inspect argument type` in Note
- `Inconsistent equals and hashCode` in Note