### PR TITLE
[Word2VecSentimentRNN] Fix a bug when predicting short reviews (fixes #761)

### DIFF
--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/word2vecsentiment/SentimentExampleIterator.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/word2vecsentiment/SentimentExampleIterator.java
@@ -254,13 +254,13 @@ public class SentimentExampleIterator implements DataSetIterator {
         for(String t : tokens ){
             if(wordVectors.hasWord(t)) tokensFiltered.add(t);
         }
-        int outputLength = Math.max(maxLength,tokensFiltered.size());
+        int outputLength = Math.min(maxLength,tokensFiltered.size());
 
         INDArray features = Nd4j.create(1, vectorSize, outputLength);
 
         int count = 0;
-        for( int j=0; j<tokens.size() && count<maxLength; j++ ){
-            String token = tokens.get(j);
+        for( int j=0; j<tokensFiltered.size() && count<maxLength; j++ ){
+            String token = tokensFiltered.get(j);
             INDArray vector = wordVectors.getWordVectorMatrix(token);
             if(vector == null){
                 continue;   //Word not in word vectors

--- a/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/word2vecsentiment/Word2VecSentimentRNN.java
+++ b/dl4j-examples/src/main/java/org/deeplearning4j/examples/recurrent/word2vecsentiment/Word2VecSentimentRNN.java
@@ -108,16 +108,16 @@ public class Word2VecSentimentRNN {
         }
 
         //After training: load a single example and generate predictions
-        File firstPositiveReviewFile = new File(FilenameUtils.concat(DATA_PATH, "aclImdb/test/pos/0_10.txt"));
-        String firstPositiveReview = FileUtils.readFileToString(firstPositiveReviewFile);
+        File shortNegativeReviewFile = new File(FilenameUtils.concat(DATA_PATH, "aclImdb/test/neg/12100_1.txt"));
+        String shortNegativeReview = FileUtils.readFileToString(shortNegativeReviewFile);
 
-        INDArray features = test.loadFeaturesFromString(firstPositiveReview, truncateReviewsToLength);
+        INDArray features = test.loadFeaturesFromString(shortNegativeReview, truncateReviewsToLength);
         INDArray networkOutput = net.output(features);
         long timeSeriesLength = networkOutput.size(2);
         INDArray probabilitiesAtLastWord = networkOutput.get(NDArrayIndex.point(0), NDArrayIndex.all(), NDArrayIndex.point(timeSeriesLength - 1));
 
         System.out.println("\n\n-------------------------------");
-        System.out.println("First positive review: \n" + firstPositiveReview);
+        System.out.println("Short negative review: \n" + shortNegativeReview);
         System.out.println("\n\nProbabilities at last time step:");
         System.out.println("p(positive): " + probabilitiesAtLastWord.getDouble(0));
         System.out.println("p(negative): " + probabilitiesAtLastWord.getDouble(1));


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Fix a bug in the `Word2VecSentimentRNN` example when predicting short reviews.

## How was this patch tested?

- Run the main method in `Word2VecSentimentRNN` with test review `neg/12100_1.txt`:
```
Hated it with all my being. Worst movie ever. Mentally- scarred. Help me. It was that bad.TRUST ME!!!
```
- Before the patch we obtain:
```
Probabilities at last time step:
p(positive): 0.5197249054908752
p(negative): 0.48027509450912476
```
- After the patch we obtain:
```
Probabilities at last time step:
p(positive): 0.08360758423805237
p(negative): 0.91639244556427
```